### PR TITLE
Fix property editor for nw0.4x+

### DIFF
--- a/hide/comp/PropsEditor.hx
+++ b/hide/comp/PropsEditor.hx
@@ -105,6 +105,12 @@ class PropsEditor extends Component {
 		e.find("input[type=checkbox]").wrap("<div class='checkbox-wrapper'></div>");
 		e.find("input[type=range]").not("[step]").attr({step: "any", tabindex:"-1"});
 
+		// Wrap dt+dd for nw versions of 0.4x+
+		for ( el in e.find("dt").wrap("<div></div>").parent().elements() ) {
+			var n = el.next();
+			if (n.length != 0 && n[0].tagName == "DD") n.appendTo(el);
+		}
+
 		// -- reload states ---
 		for( h in e.find(".section > h1").elements() )
 			if( getDisplayState("section:" + StringTools.trim(h.text())) != false )


### PR DESCRIPTION
Fixes property editors on NWJS 0.4x+. Was caused by unconventional usage of dt+dd tags. Since they were both with `display: inline-block` style, there was no line-break created between properties, causing them to cramp into one line. Fix is rather simple - wrapping those properties with a `div`.