### PR TITLE
Make new nightly builds nightly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,11 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+  schedule:
+    - cron: '0 4 * * *'
 
 jobs:
   build:
@@ -60,4 +65,4 @@ jobs:
         echo "${{secrets.DEPLOY_KEY}}" > ~/.ssh/id_rsa
         chmod 600 ~/.ssh/id_rsa
         scp -o StrictHostKeyChecking=no zips/* gama11@community.heaps.io:builds/hide
-      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
Hide probably doesn't change as often as some of its dependencies, so I think it makes sense to run CI once per day with a cronjob.