### PR TITLE
Improve 2D particle editor

### DIFF
--- a/hide/comp/Scene.hx
+++ b/hide/comp/Scene.hx
@@ -131,7 +131,7 @@ class Scene extends Component implements h3d.IDrawable {
 		engine.onResized = function() {
 			if( s2d == null ) return;
 			visible = engine.width > 32 && engine.height > 32; // 32x32 when hidden !
-			s2d.setFixedSize(engine.width, engine.height);
+			s2d.scaleMode = Stretch(engine.width, engine.height);
 			onResize();
 		};
 		engine.init();


### PR DESCRIPTION
* Added `isRelative` flag to Display group
* Altered `emitAngle` min/max/step to allow full 360 degrees.
* Added `Scene scale` to Manage section. Now editing particles for pixel-art won't be a massive pain in the ass.
* Added `Parts X`/`Parts Y` to Manage section. Allows to move particles and introduced in order to let user test how particles act when moved (especially in conjuction with `isRelative = false`).
* Added `smooth` to Background section. Lets toggle particle smoothing flag. (No more blurry particles with white outlines on pixel art)
* Fix s2d.setFixedSize warning.