### PR TITLE
Improve PropsEditor

### DIFF
--- a/hide/comp/PropsEditor.hx
+++ b/hide/comp/PropsEditor.hx
@@ -88,8 +88,9 @@ class PropsEditor extends Component {
 		return el;
 	}
 	
-	public static function makeSectionEl(name: String, content: Element) {
-		var el = new Element('<div class="section"><h1>${name}</h1><div class="content"></div></div>');
+	public static function makeSectionEl(name: String, content: Element, ?headerContent: Element) {
+		var el = new Element('<div class="section"><h1><span>${name}</span></h1><div class="content"></div></div>');
+		if (headerContent != null) headerContent.appendTo(el.find("h1"));
 		content.appendTo(el.find(".content"));
 		return el;
 	}
@@ -135,6 +136,10 @@ class PropsEditor extends Component {
 			section.children(".content").slideToggle(100);
 			saveDisplayState("section:" + StringTools.trim(e.getThis().text()), section.hasClass("open"));
 		}).find("input").mousedown(function(e) e.stopPropagation());
+		
+		e.find("input[type=section_name]").change(function(e) {
+			e.getThis().closest(".section").find(">h1 span").text(e.getThis().val());
+		});
 
 		// init groups
 		var gindex = 0;
@@ -167,6 +172,10 @@ class PropsEditor extends Component {
 			saveDisplayState("group:" + key, group.hasClass("open"));
 
 		}).find("input").mousedown(function(e) e.stopPropagation());
+		
+		e.find("input[type=group_name]").change(function(e) {
+			e.getThis().closest(".group").find(">.title").val(e.getThis().val());
+		});
 
 		// init input reflection
 		for( f in e.find("[field]").elements() ) {

--- a/hide/comp/PropsEditor.hx
+++ b/hide/comp/PropsEditor.hx
@@ -75,6 +75,10 @@ class PropsEditor extends Component {
 			var e = new Element('<select field="${p.name}"></select>').appendTo(parent);
 		case PFile(exts):
 			new Element('<input type="texturepath" extensions="${exts.join(" ")}" field="${p.name}">').appendTo(parent);
+		case PString(len):
+			var e = new Element('<input type="text" field="${p.name}">').appendTo(parent);
+			if ( len != null ) e.attr("maxlength", "" + len);
+			if ( p.def != null ) e.attr("value", "" + p.def);
 		}
 	}
 

--- a/hide/comp/PropsEditor.hx
+++ b/hide/comp/PropsEditor.hx
@@ -94,6 +94,18 @@ class PropsEditor extends Component {
 		content.appendTo(el.find(".content"));
 		return el;
 	}
+	
+	public static function makeLabelEl(name: String, content: Element) {
+		var el = new Element('<dt>${name}</dt><dd></dd>');
+		content.appendTo(el.find("dd"));
+		return el;
+	}
+	
+	public static function makeListEl(content:Array<Element>) {
+		var el = new Element("<dl>");
+		for ( e in content ) e.appendTo(el);
+		return el;
+	}
 
 	static function upperCase(prop: String) {
 		return prop.charAt(0).toUpperCase() + prop.substr(1);

--- a/hide/comp/PropsEditor.hx
+++ b/hide/comp/PropsEditor.hx
@@ -81,6 +81,18 @@ class PropsEditor extends Component {
 			if ( p.def != null ) e.attr("value", "" + p.def);
 		}
 	}
+	
+	public static function makeGroupEl(name: String, content: Element) {
+		var el = new Element('<div class="group" name="${name}"></div>');
+		content.appendTo(el);
+		return el;
+	}
+	
+	public static function makeSectionEl(name: String, content: Element) {
+		var el = new Element('<div class="section"><h1>${name}</h1><div class="content"></div></div>');
+		content.appendTo(el.find(".content"));
+		return el;
+	}
 
 	static function upperCase(prop: String) {
 		return prop.charAt(0).toUpperCase() + prop.substr(1);

--- a/hide/tools/TypesCache.hx
+++ b/hide/tools/TypesCache.hx
@@ -238,6 +238,8 @@ class TypesCache {
 			return e.getConstructors()[0];
 		case PFile(_):
 			return null;
+		case PString(_):
+			return null;
 		}
 	}
 
@@ -249,6 +251,8 @@ class TypesCache {
 			PFloat();
 		case CTPath(["Bool"]):
 			PBool;
+		case CTPath(["String"]):
+			PString();
 		default:
 			PUnsupported(new hscript.Printer().typeToString(t));
 		}

--- a/hrt/prefab/Props.hx
+++ b/hrt/prefab/Props.hx
@@ -9,6 +9,7 @@ enum PropType {
 	PChoice( choices : Array<String> );
 	PFile( exts : Array<String> );
 	PEnum( e : Enum<Dynamic>);
+	PString( ?maxLen : Int );
 	PUnsupported( debug : String );
 }
 


### PR DESCRIPTION
* Add new `PropType.PString(?maxLen:Int)`. 
* Allow creation of regular text inputs with declarative `makeProps`.
* Add helper methods to wrap content into group or section.
* Add handling of inputs with `type="section_name"` and `type="group_name"` to change their parent section/group names.
* Add helper methods to wrap input in a label and `<dd>` list. Useful for custom field views.

In general allows to use declarative props far easier.