### PR TITLE
Made it possible to extend level3d prefab

### DIFF
--- a/hide/view/l3d/Level3D.hx
+++ b/hide/view/l3d/Level3D.hx
@@ -193,7 +193,6 @@ private class Level3DSceneEditor extends hide.comp.SceneEditor {
 				function make(name) {
 					var p = new hrt.prefab.l3d.Instance(current == null ? sceneData : current);
 					p.props = type.getDefaults();
-					trace(typeId);
 					Reflect.setField(p.props, "$cdbtype", typeId);
 					p.name = name;
 					setup(p);
@@ -247,7 +246,6 @@ private class Level3DSceneEditor extends hide.comp.SceneEditor {
 
 		var select = group.find("select");
 		var cdbTypes = Level3D.getCdbTypes();
-		trace(cdbTypes);
 		for(t in cdbTypes) {
 			var current = sheet != null && sheet.name == t.name;
 			var id = Level3D.getCdbTypeId(t);

--- a/hide/view/l3d/Level3D.hx
+++ b/hide/view/l3d/Level3D.hx
@@ -193,6 +193,7 @@ private class Level3DSceneEditor extends hide.comp.SceneEditor {
 				function make(name) {
 					var p = new hrt.prefab.l3d.Instance(current == null ? sceneData : current);
 					p.props = type.getDefaults();
+					trace(typeId);
 					Reflect.setField(p.props, "$cdbtype", typeId);
 					p.name = name;
 					setup(p);
@@ -246,6 +247,7 @@ private class Level3DSceneEditor extends hide.comp.SceneEditor {
 
 		var select = group.find("select");
 		var cdbTypes = Level3D.getCdbTypes();
+		trace(cdbTypes);
 		for(t in cdbTypes) {
 			var current = sheet != null && sheet.name == t.name;
 			var id = Level3D.getCdbTypeId(t);
@@ -336,7 +338,7 @@ class Level3D extends FileView {
 					<span class="tools-buttons"></span>
 					<span class="layer-buttons"></span>
 				</div>
-				<div style="display: flex; flex-direction: row; flex: 1;">
+				<div style="display: flex; flex-direction: row; flex: 1; overflow: hidden;">
 					<div class="heaps-scene">
 					</div>
 					<div class="hide-scene-outliner">

--- a/hide/view/l3d/Level3D.hx
+++ b/hide/view/l3d/Level3D.hx
@@ -282,7 +282,7 @@ class Level3D extends FileView {
 	function get_properties() return sceneEditor.properties;
 
 	override function onDisplay() {
-		data = new hrt.prefab.l3d.Level3D();
+		data = cast(hrt.prefab.Library.create("l3d"), hrt.prefab.l3d.Level3D);
 		var content = sys.io.File.getContent(getPath());
 		data.loadData(haxe.Json.parse(content));
 		currentSign = haxe.crypto.Md5.encode(content);


### PR DESCRIPTION
I wanted to add my own level specific properties, other than grid size, width, and height.
I couldn't find anywhere if that already was possible or not, so I added this modification. 
Is there a way that I've missed?

```
class Level3D extends hrt.prefab.l3d.Level3D {
    ...
    override function edit(ctx) {....}

    static var _ = Library.register("level3d", Level3D, "l3d");
}
```