### PR TITLE
Rename applyPos to applyTransform

### DIFF
--- a/hide/comp/SceneEditor.hx
+++ b/hide/comp/SceneEditor.hx
@@ -946,7 +946,7 @@ class SceneEditor {
 						obj3d.scaleY = quantize(scaleSnap(s.y), scaleQuant);
 						obj3d.scaleZ = quantize(scaleSnap(s.z), scaleQuant);
 					}
-					obj3d.applyPos(sceneObjs[i]);
+					obj3d.applyTransform(sceneObjs[i]);
 				}
 			}
 
@@ -957,14 +957,14 @@ class SceneEditor {
 					if( undo ) {
 						for(i in 0...objects3d.length) {
 							objects3d[i].loadTransform(prevState[i]);
-							objects3d[i].applyPos(sceneObjs[i]);
+							objects3d[i].applyTransform(sceneObjs[i]);
 						}
 						refreshProps();
 					}
 					else {
 						for(i in 0...objects3d.length) {
 							objects3d[i].loadTransform(newState[i]);
-							objects3d[i].applyPos(sceneObjs[i]);
+							objects3d[i].applyTransform(sceneObjs[i]);
 						}
 						refreshProps();
 					}
@@ -1038,7 +1038,7 @@ class SceneEditor {
 					sceneObjs[i].parent.globalToLocal(pt);
 					obj.x = quantize(pt.x, posQuant);
 					obj.y = quantize(pt.y, posQuant);
-					obj.applyPos(sceneObjs[i]);
+					obj.applyTransform(sceneObjs[i]);
 				}
 			};
 			gizmo2d.onFinishMove = function() {
@@ -1048,14 +1048,14 @@ class SceneEditor {
 					if( undo ) {
 						for(i in 0...objects2d.length) {
 							objects2d[i].loadTransform(prevState[i]);
-							objects2d[i].applyPos(sceneObjs[i]);
+							objects2d[i].applyTransform(sceneObjs[i]);
 						}
 						refreshProps();
 					}
 					else {
 						for(i in 0...objects2d.length) {
 							objects2d[i].loadTransform(newState[i]);
-							objects2d[i].applyPos(sceneObjs[i]);
+							objects2d[i].applyTransform(sceneObjs[i]);
 						}
 						refreshProps();
 					}

--- a/hrt/prefab/Light.hx
+++ b/hrt/prefab/Light.hx
@@ -150,8 +150,8 @@ class Light extends Object3D {
 			shadows = getShadowsDefault();
 	}
 
-	override function applyPos( o : h3d.scene.Object ) {
-		//super.applyPos(o); // Disable scaling
+	override function applyTransform( o : h3d.scene.Object ) {
+		//super.applyTransform(o); // Disable scaling
 		o.x = x;
 		o.y = y;
 		o.z = z;

--- a/hrt/prefab/Object2D.hx
+++ b/hrt/prefab/Object2D.hx
@@ -76,7 +76,7 @@ class Object2D extends Prefab {
 		return m;
 	}
 
-	public function applyPos( o : h2d.Object ) {
+	public function applyTransform( o : h2d.Object ) {
 		o.x = x;
 		o.y = y;
 		o.scaleX = scaleX;

--- a/hrt/prefab/Object3D.hx
+++ b/hrt/prefab/Object3D.hx
@@ -103,7 +103,7 @@ class Object3D extends Prefab {
 		return m;
 	}
 
-	public function applyPos( o : h3d.scene.Object ) {
+	public function applyTransform( o : h3d.scene.Object ) {
 		o.x = x;
 		o.y = y;
 		o.z = z;
@@ -115,7 +115,7 @@ class Object3D extends Prefab {
 
 	override function updateInstance( ctx: Context, ?propName : String ) {
 		var o = ctx.local3d;
-		applyPos(o);
+		applyTransform(o);
 		o.visible = visible;
 	}
 

--- a/hrt/prefab/Trail.hx
+++ b/hrt/prefab/Trail.hx
@@ -23,7 +23,7 @@ class Trail extends Object3D {
 	public function create( ?parent : h3d.scene.Object ) {
 		var tr = new h3d.scene.Trail(parent);
 		tr.load(data);
-		applyPos(tr);
+		applyTransform(tr);
 		tr.name = name;
 		return tr;
 	}
@@ -43,7 +43,7 @@ class Trail extends Object3D {
 
 	override public function edit(ctx:EditContext) {
 		super.edit(ctx);
-		
+
 		var trailContext = ctx.getContext(this);
 		var trail = trailContext == null ? create(null) : Std.downcast(trailContext.local3d, h3d.scene.Trail);
 		var props = ctx.properties.add(new hide.Element('


### PR DESCRIPTION
This patch renames `Object{2D,3D}.applyPos()` to `.applyTransform()` for clarity, since it doesn't just apply the position but the whole transform.