### PR TITLE
Add Copy Relative Path to File Tree right click menu

### DIFF
--- a/hide/view/FileTree.hx
+++ b/hide/view/FileTree.hx
@@ -129,6 +129,13 @@ class FileTree extends FileView {
 						js.Browser.window.alert(e);
 					}
 					} },
+				{ label : "Copy Relative Path", enabled : current != null, click : function() {
+					try {
+						ide.setClipboard(current);
+					} catch (e : Dynamic) {
+						js.Browser.window.alert(e);
+					}
+					} },
 				{ label : "Move", enabled : current != null, click : function() {
 					ide.chooseDirectory(function(dir) {
 						onRename(current, "/"+dir+"/"+current.split("/").pop());

--- a/hide/view/FileTree.hx
+++ b/hide/view/FileTree.hx
@@ -112,7 +112,10 @@ class FileTree extends FileView {
 				newMenu.unshift({ label : "Directory", click : createNew.bind(current, { options : { createNew : "Directory" }, extensions : null, component : null }) });
 			new hide.comp.ContextMenu([
 				{ label : "New..", menu:newMenu },
+				{ label : "", isSeparator: true },
 				{ label : "Explore", enabled : current != null, click : function() { onExploreFile(current); } },
+				{ label : "Copy Path", enabled : current != null, click : function() { ide.setClipboard(current); } },
+				{ label : "", isSeparator: true },
 				{ label : "Clone", enabled : current != null, click : function() {
 						try {
 							if (onCloneFile(current)) {
@@ -125,13 +128,6 @@ class FileTree extends FileView {
 				{ label : "Rename", enabled : current != null, click : function() {
 					try {
 						onRenameFile(current);
-					} catch (e : Dynamic) {
-						js.Browser.window.alert(e);
-					}
-					} },
-				{ label : "Copy Relative Path", enabled : current != null, click : function() {
-					try {
-						ide.setClipboard(current);
 					} catch (e : Dynamic) {
 						js.Browser.window.alert(e);
 					}


### PR DESCRIPTION
Right clicking on a file or folder on the resource file tree now has a "Copy Relative Path" option.

Note that this will not allow for pasting to a CDB file element since that uses its own clipboard with its schema