### PR TITLE
Allow dragging from the file tree to CDB Path cells

### DIFF
--- a/hide/comp/cdb/Cell.hx
+++ b/hide/comp/cdb/Cell.hx
@@ -32,6 +32,9 @@ class Cell extends Component {
 			if(!visible)
 				return;
 		}
+
+		// Used to get the Cell component back from its DOM/Jquery element
+		root.prop("cellComp", this);
 		if( column.kind == Script ) root.addClass("t_script");
 		refresh();
 		switch( column.type ) {
@@ -41,21 +44,6 @@ class Cell extends Component {
 				e.stopPropagation();
 				@:privateAccess line.table.toggleList(this);
 			});
-		case TFile:
-			if (canEdit()) {
-				element.on("drop", function(e : js.jquery.Event) {
-					var e : js.html.DragEvent = untyped e.originalEvent;
-					if (e.dataTransfer.files.length > 0) {
-						e.preventDefault();
-						e.stopPropagation();
-						setValue(ide.makeRelative(untyped e.dataTransfer.files.item(0).path));
-						refresh();
-					}
-				});
-				element.dblclick(function(_) edit());
-			} else {
-				root.addClass("t_readonly");
-			}
 		case TString if( column.kind == Script ):
 			element.click(function(_) edit());
 		default:
@@ -74,6 +62,15 @@ class Cell extends Component {
 			e.stopPropagation();
 			e.preventDefault();
 		});
+	}
+
+	public function dragDropFile( relativePath : String, isDrop : Bool = false ) : Bool {
+		if ( !canEdit() || column.type != TFile) return false;
+		if ( isDrop ) {
+			setValue(relativePath);
+			refresh();
+		}
+		return true;
 	}
 
 	function evaluate() {

--- a/hide/view/CdbTable.hx
+++ b/hide/view/CdbTable.hx
@@ -137,6 +137,42 @@ class CdbTable extends hide.ui.View<{}> {
 		editor.refresh();
 	}
 
+	/**
+		Hovers and drops dragged in from an item tree
+	**/
+	override public function onDragDrop( items : Array<String>, isDrop : Bool ) {
+		if( items.length == 0 )
+			return false;
+		var path = ide.makeRelative(items[0]);
+		var cell = getCellFromMousePos(ide.mouseX, ide.mouseY);
+		if( cell == null )
+			return false;
+		return cell.dragDropFile(path, isDrop);
+	}
+
+	/**
+		Returns the Cell Component that is currently under position (x, y) in pixels
+		returns null otherwise.
+
+		This will not give a cell in row/column coordinates.
+	**/
+	public function getCellFromMousePos( x : Int, y : Int ) : Null<hide.comp.cdb.Cell> {
+		var pickedEl = js.Browser.document.elementFromPoint(x, y);
+		var el = pickedEl;
+		while (el != null) {
+			if(el.classList.contains("c")) {
+				// el is a cell's root DOM element
+
+				var cellRoot = new Element(el);
+				var cell : hide.comp.cdb.Cell = cellRoot.prop("cellComp");
+				return cell;
+			}
+			el = el.parentElement;
+		}
+		return null;
+	}
+
+
 	override function getTitle() {
 		return "CDB"+ @:privateAccess (ide.databaseDiff != null ? " - "+ide.databaseDiff : "");
 	}

--- a/hide/view/CdbTable.hx
+++ b/hide/view/CdbTable.hx
@@ -137,9 +137,6 @@ class CdbTable extends hide.ui.View<{}> {
 		editor.refresh();
 	}
 
-	/**
-		Hovers and drops dragged in from an item tree
-	**/
 	override public function onDragDrop( items : Array<String>, isDrop : Bool ) {
 		if( items.length == 0 )
 			return false;
@@ -150,28 +147,17 @@ class CdbTable extends hide.ui.View<{}> {
 		return cell.dragDropFile(path, isDrop);
 	}
 
-	/**
-		Returns the Cell Component that is currently under position (x, y) in pixels
-		returns null otherwise.
-
-		This will not give a cell in row/column coordinates.
-	**/
 	public function getCellFromMousePos( x : Int, y : Int ) : Null<hide.comp.cdb.Cell> {
 		var pickedEl = js.Browser.document.elementFromPoint(x, y);
 		var el = pickedEl;
 		while (el != null) {
-			if(el.classList.contains("c")) {
-				// el is a cell's root DOM element
-
-				var cellRoot = new Element(el);
-				var cell : hide.comp.cdb.Cell = cellRoot.prop("cellComp");
-				return cell;
-			}
+			var cellRoot = new Element(el);
+			var cell : hide.comp.cdb.Cell = cellRoot.prop("cellComp");
+			if (cell != null) return cell;
 			el = el.parentElement;
 		}
 		return null;
 	}
-
 
 	override function getTitle() {
 		return "CDB"+ @:privateAccess (ide.databaseDiff != null ? " - "+ide.databaseDiff : "");

--- a/hide/view/FileTree.hx
+++ b/hide/view/FileTree.hx
@@ -129,6 +129,13 @@ class FileTree extends FileView {
 						js.Browser.window.alert(e);
 					}
 					} },
+				{ label : "Copy Relative Path", enabled : current != null, click : function() {
+					try {
+						ide.setClipboard(current);
+					} catch (e : Dynamic) {
+						js.Browser.window.alert(e);
+					}
+					} },
 				{ label : "Move", enabled : current != null, click : function() {
 					ide.chooseDirectory(function(dir) {
 						onRename(current, "/"+dir+"/"+current.split("/").pop());


### PR DESCRIPTION
You can now drag from the file tree on the left into a CDB path cell.

Note that drag & drops coming from outside the file tree are now handled through `CdbTable`'s `onDragDrop()` (called by `Ide`) rather than through the cell's DOM element `.on("drop")` event.

Also note that at the moment this only applies to Path columns, and not others types which also use files.