### PR TITLE
Lock Mouse Editing Gizmo

### DIFF
--- a/hide/comp/Scene.hx
+++ b/hide/comp/Scene.hx
@@ -55,7 +55,7 @@ class Scene extends Component implements h3d.IDrawable {
 
 	var id = ++UID;
 	var window : hxd.Window;
-	var canvas : js.html.CanvasElement;
+	public var canvas : js.html.CanvasElement;
 	var hmdCache = new Map<String, hxd.fmt.hmd.Library>();
 	var texCache = new Map<String, h3d.mat.Texture>();
 	var pathsMap = new Map<String, String>();

--- a/hide/view/l3d/Gizmo.hx
+++ b/hide/view/l3d/Gizmo.hx
@@ -1,4 +1,7 @@
 package hide.view.l3d;
+import js.html.Document;
+import js.html.CanvasElement;
+import hxd.System;
 import hxd.Math;
 import hxd.Key as K;
 
@@ -112,6 +115,7 @@ class Gizmo extends h3d.scene.Object {
 	}
 
 	public function startMove(mode: TransformMode, ?duplicating=false) {
+		scene.canvas.requestPointerLock();
 		moving = true;
 		if(onStartMove != null) onStartMove(mode);
 		var startMat = getAbsPos().clone();
@@ -219,6 +223,7 @@ class Gizmo extends h3d.scene.Object {
 	function get_mouseY() return @:privateAccess scene.window.mouseY;
 
 	function finishMove() {
+		scene.canvas.ownerDocument.exitPointerLock();
 		updateFunc = null;
 		if(onFinishMove != null)
 			onFinishMove();

--- a/hide/view/l3d/Gizmo.hx
+++ b/hide/view/l3d/Gizmo.hx
@@ -28,6 +28,7 @@ class Gizmo extends h3d.scene.Object {
 	var updateFunc: Float -> Void;
 	var mouseX(get,never) : Float;
 	var mouseY(get,never) : Float;
+	var mouseLock(get, set) : Bool;
 
 	public var onStartMove: TransformMode -> Void;
 	public var onMove: h3d.Vector -> h3d.Quat -> h3d.Vector -> Void;
@@ -112,7 +113,7 @@ class Gizmo extends h3d.scene.Object {
 	}
 
 	public function startMove(mode: TransformMode, ?duplicating=false) {
-		scene.canvas.requestPointerLock();
+		mouseLock = true;
 		moving = true;
 		if(onStartMove != null) onStartMove(mode);
 		var startMat = getAbsPos().clone();
@@ -218,9 +219,11 @@ class Gizmo extends h3d.scene.Object {
 
 	function get_mouseX() return @:privateAccess scene.window.mouseX;
 	function get_mouseY() return @:privateAccess scene.window.mouseY;
+	function get_mouseLock() return @:privateAccess scene.window.mouseLock;
+	function set_mouseLock(v : Bool) return @:privateAccess scene.window.mouseLock = v; 
 
 	function finishMove() {
-		scene.canvas.ownerDocument.exitPointerLock();
+		mouseLock = false;
 		updateFunc = null;
 		if(onFinishMove != null)
 			onFinishMove();

--- a/hide/view/l3d/Gizmo.hx
+++ b/hide/view/l3d/Gizmo.hx
@@ -1,7 +1,4 @@
 package hide.view.l3d;
-import js.html.Document;
-import js.html.CanvasElement;
-import hxd.System;
 import hxd.Math;
 import hxd.Key as K;
 


### PR DESCRIPTION
When editing object transform using the 3d gizmo, mouse now goes into lock mode (hidden and not limited by window boundaries).