### PR TITLE
CDB Paste file paths from external/generic clipboards

### DIFF
--- a/hide/comp/cdb/Editor.hx
+++ b/hide/comp/cdb/Editor.hx
@@ -270,6 +270,8 @@ class Editor extends Component {
 						if( ~/^[A-Za-z0-9_]+$/.match(text) ) value = text;
 					case TString:
 						value = text;
+					case TFile:
+						value = ide.makeRelative(text);
 					case TInt:
 						text = text.split(",").join("").split(" ").join("");
 						value = Std.parseInt(text);


### PR DESCRIPTION
We can now use ctrl+v on a file path cell in cdb to paste a generic text from external clipboards.
Use this with pr/112.