### PR TITLE
Fix scene file watcher leak

### DIFF
--- a/hide/comp/Scene.hx
+++ b/hide/comp/Scene.hx
@@ -280,10 +280,11 @@ class Scene extends Component implements h3d.IDrawable {
 			}
 		}
 		img.on("load", onLoaded);
-		var w = js.node.Fs.watch(path, function(_, _) {
-			img.attr("src", 'file://$path?t='+Date.now().getTime());
-		});
-		cleanup.push(w.close);
+		function onChange() {
+			img.attr("src", 'file://$path?t=' + Std.int(Date.now().getTime() / 1000));
+		}
+		ide.fileWatcher.register( path, onChange, true, element );
+		cleanup.push(function() { ide.fileWatcher.unregister( path, onChange ); });
 	}
 
 	public function listAnims( path : String ) {

--- a/hide/view/Image.hx
+++ b/hide/view/Image.hx
@@ -99,6 +99,12 @@ class Image extends FileView {
 		};
 	}
 
+	override function onRebuild() {
+		if ( scene != null )
+			scene.dispose();
+		super.onRebuild();
+	}
+
 	override function onResize() {
 		if( bmp == null ) return;
 		var scale = Math.min(1,Math.min((contentWidth - 20) / bmp.tile.width, (contentHeight - 20) / bmp.tile.height));


### PR DESCRIPTION
If you repeatedly close and open a file in hide, editing the file  will no longer trigger an extensive amount of fetches to it