### PR TITLE
Overflow CDB tabs to next line

### DIFF
--- a/bin/style.css
+++ b/bin/style.css
@@ -474,7 +474,7 @@ input[type=checkbox]:checked:after {
 }
 .hide-tabs.tabs-bottom > .tabs-header {
   width: 100%;
-  position: fixed;
+  position: absolute;
   bottom: 0px;
   padding-top: 0px;
   padding-bottom: 5px;

--- a/bin/style.less
+++ b/bin/style.less
@@ -510,7 +510,7 @@ input[type=checkbox] {
 .hide-tabs.tabs-bottom {
 	>.tabs-header {
 		width:100%;
-		position: fixed;
+		position: absolute;
 		bottom : 0px;
 		padding-top : 0px;
 		padding-bottom : 5px;


### PR DESCRIPTION
The cdb tab header is now only as wide as its container rather than as wide as the entire hide window

Before:  
![image](https://user-images.githubusercontent.com/22801009/121163195-e0d51f80-c84e-11eb-9131-c4cc1ab645a6.png)

After:  
![image](https://user-images.githubusercontent.com/22801009/121162991-b5523500-c84e-11eb-8622-be0f4c00dc1e.png)
