### PR TITLE
Drop support for internal references prefabs

### DIFF
--- a/hide/comp/SceneEditor.hx
+++ b/hide/comp/SceneEditor.hx
@@ -516,11 +516,10 @@ class SceneEditor {
 				{ label : "Rename", enabled : current != null, click : function() tree.editNode(current) },
 				{ label : "Delete", enabled : current != null, click : function() deleteElements(curEdit.rootElements) },
 				{ label : "Duplicate", enabled : current != null, click : duplicate.bind(false) },
-				{ label : "Reference", enabled : current != null, click : function() createRef(current, current.parent) },
 			];
 
 			var isObj = current != null && (current.to(Object3D) != null || current.to(Object2D) != null);
-			var isRef = current != null && current.to(hrt.prefab.Reference) != null;
+			var isRef = isReference(current);
 
 			if( isObj ) {
 				var visible = !isHidden(current);
@@ -1820,7 +1819,7 @@ class SceneEditor {
 
 	public function setEnabled(elements : Array<PrefabElement>, enable: Bool) {
 		// Don't disable/enable Object3Ds, too confusing with visibility
-		elements = [for(e in elements) if(e.to(Object3D) == null || e.to(hrt.prefab.Reference) != null) e];
+		elements = [for(e in elements) if(e.to(Object3D) == null || isReference(e)) e];
 		var old = [for(e in elements) e.enabled];
 		function apply(on) {
 			for(i in 0...elements.length) {
@@ -1934,25 +1933,6 @@ class SceneEditor {
 			hideSiblings(e);
 		}
 		setVisible(toHide, false);
-	}
-
-	function createRef(elt: PrefabElement, toParent: PrefabElement) {
-		var ref = new hrt.prefab.Reference(toParent);
-		ref.name = elt.name;
-		ref.source = "/"+elt.getAbsPath();
-		var obj3d = Std.downcast(elt, Object3D);
-		if(obj3d != null) {
-			ref.x = obj3d.x;
-			ref.y = obj3d.y;
-			ref.z = obj3d.z;
-			ref.scaleX = obj3d.scaleX;
-			ref.scaleY = obj3d.scaleY;
-			ref.scaleZ = obj3d.scaleZ;
-			ref.rotationX = obj3d.rotationX;
-			ref.rotationY = obj3d.rotationY;
-			ref.rotationZ = obj3d.rotationZ;
-		}
-		addObject([ref]);
 	}
 
 	function duplicate(thenMove: Bool) {
@@ -2070,10 +2050,8 @@ class SceneEditor {
 		if( to == null )
 			to = sceneData;
 
-		{
-			var ref = Std.downcast(to, Reference);
-			@:privateAccess if( ref != null && ref.editMode ) to = ref.ref;
-		}
+		var ref = Std.downcast(to, Reference);
+		@:privateAccess if( ref != null && ref.editMode ) to = ref.ref;
 
 		var effectFunc = reparentImpl(e, to, index);
 		undo.change(Custom(function(undo) {
@@ -2579,6 +2557,10 @@ class SceneEditor {
 			}
 		}
 		return bestVertex;
+	}
+
+	static function isReference( what : PrefabElement ) : Bool {
+		return what != null && what.to(hrt.prefab.Reference) != null;
 	}
 
 	static function getPivot(objects: Array<Object>) {


### PR DESCRIPTION
Reference objects are now for files only.

Clicking on the reference field in the property editor now opens the file explorer.