### PR TITLE
Better lock mouse editing

### DIFF
--- a/hide/view/l3d/Gizmo.hx
+++ b/hide/view/l3d/Gizmo.hx
@@ -113,7 +113,8 @@ class Gizmo extends h3d.scene.Object {
 	}
 
 	public function startMove(mode: TransformMode, ?duplicating=false) {
-		mouseLock = true;
+		if (mode == Scale || mode == RotateX || mode == RotateY || mode == RotateZ)
+			mouseLock = true;
 		moving = true;
 		if(onStartMove != null) onStartMove(mode);
 		var startMat = getAbsPos().clone();

--- a/hide/view/l3d/Level3D.hx
+++ b/hide/view/l3d/Level3D.hx
@@ -42,12 +42,14 @@ class CamController extends h3d.scene.CameraController {
 			pushStartX = pushX = e.relX;
 			pushStartY = pushY = e.relY;
 			startPush = new h2d.col.Point(pushX, pushY);
+			@:privateAccess scene.window.mouseLock = true;
 		case ERelease, EReleaseOutside:
 			if( pushing == e.button ) {
 				pushing = -1;
 				startPush = null;
 				if( e.kind == ERelease && haxe.Timer.stamp() - pushTime < 0.2 && hxd.Math.distance(e.relX - pushStartX,e.relY - pushStartY) < 5 )
 					onClick(e);
+				@:privateAccess scene.window.mouseLock = false;
 			}
 		case EMove:
 			switch( pushing ) {


### PR DESCRIPTION
Remove lock mouse when translating an object with gizmo
Add lock mouse on camera movement on l3d (rotation with wheel click and translation with right click)