### PR TITLE
Remove mouseLock when opening l3d

### DIFF
--- a/hide/view/l3d/Level3D.hx
+++ b/hide/view/l3d/Level3D.hx
@@ -80,6 +80,8 @@ class CamController extends h3d.scene.CameraController {
 				pushY = e.relY;
 			default:
 			}
+		case EFocus:
+			@:privateAccess scene.window.mouseLock = false;
 		default:
 		}
 	}


### PR DESCRIPTION
Sometimes the mouse stayed locked when changing between tabs in hide.
The mouseLock is now set to false every time we open a 3d scene to fix this.