### PR TITLE
Bug fix undo unselect mesh spray

### DIFF
--- a/hide/comp/SceneEditor.hx
+++ b/hide/comp/SceneEditor.hx
@@ -1899,7 +1899,7 @@ class SceneEditor {
 		saveDisplayState();
 	}
 
-	public function setLock(elements : Array<PrefabElement>, locked: Bool) {
+	public function setLock(elements : Array<PrefabElement>, locked: Bool, enableUndo : Bool = true) {
 		var prev = [for( o in elements ) o.locked];
 		for(o in elements) {
 			o.locked = locked;
@@ -1910,13 +1910,16 @@ class SceneEditor {
 				toggleInteractive(c,!isLocked(c));
 			}
 		}
-		undo.change(Custom(function(redo) {
-			for( i in 0...elements.length )
-				elements[i].locked = redo ? locked : prev[i];
-		}), function() {
-			tree.refresh();
-			refreshScene();
-		});
+		if (enableUndo) {
+			undo.change(Custom(function(redo) {
+				for( i in 0...elements.length )
+					elements[i].locked = redo ? locked : prev[i];
+			}), function() {
+				tree.refresh();
+				refreshScene();
+			});
+		}
+		
 		saveDisplayState();
 		showGizmo = !locked;
 		moveGizmoToSelection();

--- a/hrt/prefab/l3d/MeshSpray.hx
+++ b/hrt/prefab/l3d/MeshSpray.hx
@@ -551,13 +551,12 @@ class MeshSpray extends Object3D {
 		var enableBrush = options.find("#enableBrush");
 		enableBrush.on("change", function() {
 			currentConfig.enableBrush = enableBrush.is(":checked");
-			sceneEditor.setLock([this], currentConfig.enableBrush);
+			sceneEditor.setLock([this], currentConfig.enableBrush, false);
 			removeInteractiveBrush();
 			if (currentConfig.enableBrush)
 				createInteractiveBrush(ectx);
 			else {
 				interactive.cancelEvents = true;
-				sceneEditor.setLock([this], currentConfig.enableBrush);
 			}
 			
 		}).prop("checked", currentConfig.enableBrush);
@@ -632,7 +631,7 @@ class MeshSpray extends Object3D {
 			saveConfigMeshBatch();
 		});
 
-		sceneEditor.setLock([this], currentConfig.enableBrush);
+		sceneEditor.setLock([this], currentConfig.enableBrush, false);
 		removeInteractiveBrush();
 		if (currentConfig.enableBrush)
 			createInteractiveBrush(ectx);


### PR DESCRIPTION
After selecting a mesh spray hitting ctrl+Z to undo the selection left the brush active even though the mesh spray was unselected. This is now fixed