### PR TITLE
Add file version to watches in FileWatcher

### DIFF
--- a/hide/Ide.hx
+++ b/hide/Ide.hx
@@ -824,8 +824,7 @@ class Ide {
 	}
 
 	public function getUnCachedUrl( path : String ) {
-		var timestamp = Std.int(Date.now().getTime() / 1000);
-		return "file://" + getPath(path) + "?t=" + timestamp;
+		return "file://" + getPath(path) + "?t=" + fileWatcher.getVersion(path);
 	}
 
 	public static var IMG_EXTS = ["jpg", "jpeg", "gif", "png", "raw", "dds", "hdr", "tga"];


### PR DESCRIPTION
Also made `register()` and `unregister()` use `ide.getPath()` to keep
one watch per file, even if called mutiple times with different paths to
the same file