### PR TITLE
Add jump to last/next cursor position in cdb

### DIFF
--- a/bin/defaultProps.json
+++ b/bin/defaultProps.json
@@ -62,6 +62,8 @@
 	"key.cdb.closeList" : "Escape",
 	"key.cdb.editCell" : "Enter",
 	"key.cdb.insertLine" : "Insert",
+	"key.cdb.moveBack" : "Alt-Left",
+	"key.cdb.moveAhead" : "Alt-Right",
 
 	// Scene editor config
 	"key.sceneeditor.focus": "F",

--- a/hide/comp/cdb/Cell.hx
+++ b/hide/comp/cdb/Cell.hx
@@ -38,6 +38,11 @@ class Cell extends Component {
 		root.prop("cellComp", this);
 		if( column.kind == Script ) root.addClass("t_script");
 		refresh();
+
+		root.click(function(e) {
+			editor.cursor.clickCell(this, e.shiftKey);
+			e.stopPropagation();
+		});
 		switch( column.type ) {
 		case TList, TProperties:
 			element.click(function(e) {
@@ -54,10 +59,6 @@ class Cell extends Component {
 				root.addClass("t_readonly");
 		}
 
-		root.click(function(e) {
-			editor.cursor.clickCell(this, e.shiftKey);
-			e.stopPropagation();
-		});
 		root.contextmenu(function(e) {
 			showMenu();
 			e.stopPropagation();

--- a/hide/comp/cdb/Cursor.hx
+++ b/hide/comp/cdb/Cursor.hx
@@ -1,5 +1,13 @@
 package hide.comp.cdb;
 
+
+typedef CursorState = {
+	var sheet : String;
+	var x : Int;
+	var y : Int;
+	var select : Null<{ x : Int, y : Int }>;
+}
+
 class Cursor {
 
 	var editor : Editor;
@@ -12,6 +20,22 @@ class Cursor {
 	public function new(editor) {
 		this.editor = editor;
 		set();
+	}
+
+	public function setState(state : CursorState, ?table : Table) {
+		if( state == null )
+			set(table);
+		else
+			set(table, state.x, state.y, state.select);
+	}
+
+	public function getState() : CursorState {
+		return table == null ? null : {
+			sheet : table.sheet.getPath(),
+			x : x,
+			y : y,
+			select : Reflect.copy(select)
+		};
 	}
 
 	public function set( ?t:Table, ?x=0, ?y=0, ?sel, update = true ) {
@@ -210,8 +234,10 @@ class Cursor {
 		if( shiftKey && this.table == line.table && x < 0 ) {
 			select = { x : -1, y : line.index };
 			update();
-		} else
+		} else {
+			editor.pushCursorState();
 			set(line.table, -1, line.index);
+		}
 	}
 
 	public function clickCell( cell : Cell, shiftKey = false ) {
@@ -219,8 +245,10 @@ class Cursor {
 		if( shiftKey && table == cell.table ) {
 			select = { x : xIndex, y : cell.line.index };
 			update();
-		} else
+		} else {
+			editor.pushCursorState();
 			set(cell.table, xIndex, cell.line.index);
+		}
 	}
 
 }

--- a/hide/view/CdbTable.hx
+++ b/hide/view/CdbTable.hx
@@ -11,14 +11,14 @@ class CdbTable extends hide.ui.View<{}> {
 
 	public function new( ?state ) {
 		super(state);
-		editor = new hide.comp.cdb.Editor(config,{
+		editor = new hide.comp.cdb.Editor(config, {
 			copy : () -> (ide.database.save() : Any),
 			load : (v:Any) -> ide.database.load((v:String)),
 			save : function() {
 				ide.saveDatabase();
 				haxe.Timer.delay(syncTabs,0);
 			}
-		});
+		}, this);
 		undo = editor.undo;
 		currentSheet = this.config.get("cdb.currentSheet");
 		view = cast this.config.get("cdb.view");
@@ -56,6 +56,7 @@ class CdbTable extends hide.ui.View<{}> {
 
 	function setEditor(index:Int) {
 		var sheets = getSheets();
+		editor.pushCursorState();
 		editor.show(sheets[index],tabContents[index]);
 		currentSheet = editor.getCurrentSheet();
 		ide.currentConfig.set("cdb.currentSheet", sheets[index].name);


### PR DESCRIPTION
You can now use the side mouse buttons or Alt-Left and Alt-Right to jump the cursor position.

If you want to change the keyboard shortcuts in props.json, change the `key.cdb.moveBack` and `key.cdb.moveAhead` properties.