### PR TITLE
Use camera minDistance to limit maximum zoom

### DIFF
--- a/hide/comp/SceneEditor.hx
+++ b/hide/comp/SceneEditor.hx
@@ -308,6 +308,7 @@ class SceneEditor {
 		c.panSpeed = 0.6;
 		c.zoomAmount = 1.05;
 		c.smooth = 0.7;
+		c.minDistance = 1;
 		return c;
 	}
 

--- a/hide/view/l3d/Level3D.hx
+++ b/hide/view/l3d/Level3D.hx
@@ -103,6 +103,7 @@ private class Level3DSceneEditor extends hide.comp.SceneEditor {
 		c.panSpeed = 0.6;
 		c.zoomAmount = 1.05;
 		c.smooth = 0.7;
+		c.minDistance = 1;
 		return c;
 	}
 


### PR DESCRIPTION
This will make scrolling beyond a certain point move the camera rather than zoom it.

This PR is dependent on this Heaps PR https://github.com/HeapsIO/heaps/pull/977

![capped zoom](https://user-images.githubusercontent.com/22801009/124001721-36779480-d9d5-11eb-8302-fbd91648419c.gif)