### PR TITLE
Make camera rotation pivot around the ground when facing it

### DIFF
--- a/hide/comp/SceneEditor.hx
+++ b/hide/comp/SceneEditor.hx
@@ -2428,10 +2428,23 @@ class SceneEditor {
 
 		var zPlane = h3d.col.Plane.Z(0);
 		var pt = ray.intersect(zPlane);
-		if( pt != null )
+		if( pt != null ) {
 			minDist = pt.sub(ray.getPos()).length();
+			var dirToPt = pt.sub(ray.getPos());
+			if( dirToPt.dot(ray.getDir()) < 0 )
+				return -1;
+		}
 
 		return minDist;
+	}
+
+	public function screenDistToGround(sx : Float, sy : Float, ?paintOn : hrt.prefab.Prefab) : Null<Float> {
+		var camera = scene.s3d.camera;
+		var ray = camera.rayFromScreen(sx, sy);
+		var dist = projectToGround(ray, paintOn);
+		if( dist >= 0 )
+			return dist + camera.zNear;
+		return null;
 	}
 
 	public function screenToGround(sx: Float, sy: Float, ?paintOn : hrt.prefab.Prefab ) {

--- a/hide/view/l3d/Level3D.hx
+++ b/hide/view/l3d/Level3D.hx
@@ -21,6 +21,7 @@ class LevelEditContext extends hide.prefab.EditContext {
 
 @:access(hide.view.l3d.Level3D)
 class CamController extends h3d.scene.CameraController {
+	public var groundSnapAngle = hxd.Math.degToRad(30);
 	var level3d : Level3D;
 	var startPush : h2d.col.Point;
 
@@ -36,12 +37,22 @@ class CamController extends h3d.scene.CameraController {
 			zoom(e.wheelDelta);
 		case EPush:
 			pushing = e.button;
-			pushX = e.relX;
-			pushY = e.relY;
 			pushTime = haxe.Timer.stamp();
 			pushStartX = pushX = e.relX;
 			pushStartY = pushY = e.relY;
 			startPush = new h2d.col.Point(pushX, pushY);
+			if( pushing == 2 ) {
+				var se = level3d.sceneEditor;
+				var selection = se.getSelection();
+				var angle = hxd.Math.abs(Math.PI/2 - phi);
+				if( selection.length == 0 && angle > groundSnapAngle ) {
+					var visGround = se.screenToGround(se.scene.s2d.width / 2, se.scene.s2d.height / 2);
+					var dist = se.screenDistToGround(se.scene.s2d.width / 2, se.scene.s2d.height / 2);
+					if( dist != null ) {
+						set(dist, null, null, visGround);
+					}
+				}
+			}
 			@:privateAccess scene.window.mouseLock = true;
 		case ERelease, EReleaseOutside:
 			if( pushing == e.button ) {
@@ -55,9 +66,8 @@ class CamController extends h3d.scene.CameraController {
 			switch( pushing ) {
 			case 1:
 				if(startPush != null && startPush.distance(new h2d.col.Point(e.relX, e.relY)) > 3) {
-					var lowAngle = hxd.Math.degToRad(30);
 					var angle = hxd.Math.abs(Math.PI/2 - phi);
-					if(hxd.Key.isDown(hxd.Key.SHIFT) || angle < lowAngle) {
+					if(hxd.Key.isDown(hxd.Key.SHIFT) || angle < groundSnapAngle) {
 						var m = 0.001 * curPos.x * panSpeed / 25;
 						pan(-(e.relX - pushX) * m, (e.relY - pushY) * m);
 					}


### PR DESCRIPTION
Note: This happens only when no object is selected in the scene (press `esc` to deselect everything).

Rotating the camera while looking at the ground will rotate around the ground instead of around a floating coordinate