### PR TITLE
Move script error messages to bottom right

### DIFF
--- a/bin/style.css
+++ b/bin/style.css
@@ -1746,6 +1746,7 @@ div.sp-container input:hover {
   position: absolute;
   margin-top: -20px;
   padding: 2px;
+  right: 13px;
   border: 1px solid #A00;
 }
 .script-editor .codeeditor {

--- a/bin/style.less
+++ b/bin/style.less
@@ -1981,6 +1981,7 @@ div.sp-container {
 		position: absolute;
 		margin-top : -20px;
 		padding: 2px;
+		right : 13px;
 		border: 1px solid #A00;
 	}
 }


### PR DESCRIPTION
Does not cover the last lines of a script anymore
![image](https://user-images.githubusercontent.com/22801009/124494271-ec1c5c00-ddb6-11eb-87a5-18a999c48419.png)
