### PR TITLE
Work around cursor jump bug

### DIFF
--- a/hide/view/l3d/Level3D.hx
+++ b/hide/view/l3d/Level3D.hx
@@ -24,6 +24,7 @@ class CamController extends h3d.scene.CameraController {
 	public var groundSnapAngle = hxd.Math.degToRad(30);
 	var level3d : Level3D;
 	var startPush : h2d.col.Point;
+	var moveCount = 0;
 
 	public function new(parent, level3d) {
 		super(null, parent);
@@ -53,6 +54,7 @@ class CamController extends h3d.scene.CameraController {
 					}
 				}
 			}
+			moveCount = 0;
 			@:privateAccess scene.window.mouseLock = true;
 		case ERelease, EReleaseOutside:
 			if( pushing == e.button ) {
@@ -63,6 +65,14 @@ class CamController extends h3d.scene.CameraController {
 				@:privateAccess scene.window.mouseLock = false;
 			}
 		case EMove:
+			// Windows bug that jumps movementX/Y on all browsers
+			if( moveCount < 10 && Math.distanceSq(pushX - e.relX, pushY - e.relY) > 100000 ) {
+				pushX = e.relX;
+				pushY = e.relY;
+				return;
+			}
+			moveCount++;
+
 			switch( pushing ) {
 			case 1:
 				if(startPush != null && startPush.distance(new h2d.col.Point(e.relX, e.relY)) > 3) {


### PR DESCRIPTION
This is a workaround fix to an issue where clicking while moving the mouse near the l3d scene canvas edge would jump and make a wide rotation/pan (depending on the mouse button used).

The bug seems to come from windows as it is present on both Chrome and Firefox.  
It happens only when the mouse is doing sharp movements as the mouse gets locked.  
You can test that on [this page](https://scheib.github.io/HTMLMisc/PointerLockLog.html), which is linked from this [Chromium issue from 2017](https://bugs.chromium.org/p/chromium/issues/detail?id=781182).