### PR TITLE
Fix color cells going over the column name

### DIFF
--- a/bin/cdb.css
+++ b/bin/cdb.css
@@ -263,7 +263,6 @@
 }
 .cdb .cdb-sheet td.t_color {
   text-align: center;
-  position: relative;
 }
 .cdb .cdb-sheet td.t_color ._hide-modal {
   opacity: 0;

--- a/bin/cdb.less
+++ b/bin/cdb.less
@@ -293,7 +293,6 @@
 
 		td.t_color {
 			text-align : center;
-			position: relative;
 			._hide-modal {
 				opacity : 0;
 			}


### PR DESCRIPTION
This prevented clicking the column name unless scrolled up