### PR TITLE
Better rules to allow movement in SceneTree

### DIFF
--- a/hide/comp/SceneEditor.hx
+++ b/hide/comp/SceneEditor.hx
@@ -588,13 +588,19 @@ class SceneEditor {
 			return true;
 		};
 		tree.onAllowMove = function(e, to) {
-			// var allowMove = false;
-			// if (to == null && e.getHideProps().allowParent == null) allowMove = true;
-			// else if (to == null) allowMove = false;
-			// else if (to.getHideProps().allowChildren != null && to.getHideProps().allowChildren(e.type) 
-			// && e.getHideProps().allowParent != null && e.getHideProps().allowParent(to))
-			// 	allowMove = true;
-			return true;
+			if (e.getHideProps().allowParent == null)
+				if (to == null || to.getHideProps().allowChildren == null || (to.getHideProps().allowChildren != null && to.getHideProps().allowChildren(e.type)))
+					return true;
+				else return false;
+			if (to == null)
+				if (e.getHideProps().allowParent(sceneData))
+					return true;
+				else return false;
+
+			if ((to.getHideProps().allowChildren == null || to.getHideProps().allowChildren != null && to.getHideProps().allowChildren(e.type))
+			&& e.getHideProps().allowParent(to))
+				return true;
+			return false;
 		};
 
 		// Batch tree.onMove, which is called for every node moved, causing problems with undo and refresh

--- a/hrt/prefab/l3d/Spline.hx
+++ b/hrt/prefab/l3d/Spline.hx
@@ -318,10 +318,18 @@ class Spline extends Object3D {
 		// Linear interpolation between the two samples
 		else {
 			var segmentLength = data.samples[s1].pos.distance(data.samples[s2].pos);
-			var t = (l - (s1 * 1./step)) / segmentLength;
-			pos.lerp(data.samples[s1].pos, data.samples[s2].pos, t);
-			if(tangent != null)
-				tangent.lerp(data.samples[s1].tangent, data.samples[s2].tangent, t);
+			if (segmentLength == 0) {
+				pos.load(data.samples[s1].pos);
+				if(tangent != null)
+					tangent.load(data.samples[s1].tangent);
+			}
+			else {
+				var t = (l - (s1 * 1./step)) / segmentLength;
+				pos.lerp(data.samples[s1].pos, data.samples[s2].pos, t);
+				if(tangent != null)
+					tangent.lerp(data.samples[s1].tangent, data.samples[s2].tangent, t);
+			}
+			
 		}
 		return pos;
 	}
@@ -368,10 +376,12 @@ class Spline extends Object3D {
 			var t = 0.;
 			while (t <= 1.) {
 				var p = getPointBetween(t, curP, nextP);
-				samples.insert(samples.length, { pos : p, tangent : getTangentBetween(t, curP, nextP), prev : curP, next : nextP });
+				if (p.distance(samples[samples.length - 1].pos) >= 1./step)
+					samples.insert(samples.length, { pos : p, tangent : getTangentBetween(t, curP, nextP), prev : curP, next : nextP });
 				t += 1./step;
 			}
-			samples.insert(samples.length, { pos : nextP.getPoint(), tangent : nextP.getTangent(), prev : curP, next : nextP, t : 1.0 });
+			if (nextP.getPoint().distance(samples[samples.length - 1].pos) >= 1./step)
+				samples.insert(samples.length, { pos : nextP.getPoint(), tangent : nextP.getTangent(), prev : curP, next : nextP, t : 1.0 });
 			curP = points[i];
 			nextP = points[(i + 1) % points.length];
 


### PR DESCRIPTION
Movement in scene tree now follows accurately behaviour in allowParent and allowChildren.
Default behaviour :
If allowParent is null, all object are allowed as parent
If allowChildren is null, all object are allowed as children
Object must have the scene type in their parent in ordre to be moved in root of the tree