### PR TITLE
Fix line context menu 'Move Up' option

### DIFF
--- a/hide/comp/cdb/Editor.hx
+++ b/hide/comp/cdb/Editor.hx
@@ -1026,7 +1026,7 @@ class Editor extends Component {
 			}
 		}
 		new hide.comp.ContextMenu([
-			{ label : "Move Up", enabled:  (line.index > 0), click : moveLine.bind(line,-1) },
+			{ label : "Move Up", enabled:  (line.index > 0 || sepIndex >= 0), click : moveLine.bind(line,-1) },
 			{ label : "Move Down", enabled:  (line.index < sheet.lines.length - 1), click : moveLine.bind(line,1) },
 			{ label : "Move to Group", enabled : sheet.props.separatorTitles != null, menu : moveSubmenu },
 			{ label : "Insert", click : function() {


### PR DESCRIPTION
If the line had a separator above it the 'Move Up' option was disabled.