### PR TITLE
Fix selected scenetree element not being marked after removing tag

### DIFF
--- a/hide/comp/SceneEditor.hx
+++ b/hide/comp/SceneEditor.hx
@@ -1181,8 +1181,8 @@ class SceneEditor {
 			el.find("ul").first().css("background", tag.color + "80");
 		}
 		else if(pname == "tag") {
-			aEl.css("background", "none");
-			el.find("ul").first().css("background", "none");
+			aEl.css("background", "");
+			el.find("ul").first().css("background", "");
 		}
 
 		if(obj3d != null) {


### PR DESCRIPTION
Until now removing a tag from an element would make it so that it would not be highlighted in blue when selected anymore