### PR TITLE
Disable layout reordering

### DIFF
--- a/hide/Ide.hx
+++ b/hide/Ide.hx
@@ -308,6 +308,7 @@ class Ide {
 
 		var config : golden.Config = {
 			content: state.state.content,
+			settings: {reorderEnabled : false, showPopoutIcon : false, showMaximiseIcon : false}
 		};
 		var comps = new Map();
 		for( vcl in hide.ui.View.viewClasses )


### PR DESCRIPTION
Prevent users from moving resources panel and reorganizing layout.
It was happening mostly on accident anyways.

Also disable changing file view tabs order via drag and drop.