### PR TITLE
Move Recents to top of New... contextmenu option

### DIFF
--- a/hide/comp/SceneEditor.hx
+++ b/hide/comp/SceneEditor.hx
@@ -2180,6 +2180,18 @@ class SceneEditor {
 		return edit;
 	}
 
+	function getNewRecentContextMenu(current, ?onMake: PrefabElement->Void=null) : Array<hide.comp.ContextMenu.ContextMenuItem> {
+		var parent = current == null ? sceneData : current;
+		var grecent = [];
+		var recents : Array<String> = ide.currentConfig.get("sceneeditor.newrecents", []);
+		for( g in recents) {
+			var pmodel = hrt.prefab.Library.getRegistered().get(g);
+			if (checkAllowParent({cl : g, inf : pmodel.inf}, parent))
+				grecent.push(getNewTypeMenuItem(g, parent, onMake));
+		}
+		return grecent;
+	}
+
 	// Override
 	function getNewContextMenu(current: PrefabElement, ?onMake: PrefabElement->Void=null, ?groupByType=true ) : Array<hide.comp.ContextMenu.ContextMenuItem> {
 		var newItems = new Array<hide.comp.ContextMenu.ContextMenuItem>();
@@ -2187,25 +2199,9 @@ class SceneEditor {
 		allRegs.remove("reference");
 		allRegs.remove("unknown");
 		var parent = current == null ? sceneData : current;
-		var allowChildren = null;
-		{
-			var cur = parent;
-			while( allowChildren == null && cur != null ) {
-				allowChildren = cur.getHideProps().allowChildren;
-				cur = cur.parent;
-			}
-		}
 
-		var grecent = [];
 		var groups = [];
 		var gother = [];
-		var recents : Array<String> = ide.currentConfig.get("sceneeditor.newrecents", []);
-		for( g in recents) {
-			var pmodel = hrt.prefab.Library.getRegistered().get(g);
-			if (checkAllowParent({cl : g, inf : pmodel.inf}, parent)) 
-				grecent.push(getNewTypeMenuItem(g, parent, onMake));
-
-		}
 
 		for( g in (view.config.get("sceneeditor.newgroups") : Array<String>) ) {
 			var parts = g.split("|");
@@ -2253,8 +2249,6 @@ class SceneEditor {
 				return gother;
 			newItems.push({ label : "Other", menu : gother });
 		}
-
-		newItems.unshift({label : "Recents", menu : grecent});
 
 		return newItems;
 	}

--- a/hide/view/FXEditor.hx
+++ b/hide/view/FXEditor.hx
@@ -76,6 +76,7 @@ private class FXSceneEditor extends hide.comp.SceneEditor {
 			return ret;
 		}
 		var allTypes = super.getNewContextMenu(current, onMake, false);
+		var recents = getNewRecentContextMenu(current, onMake);
 
 		var menu = [];
 		if (parent.is2D) {
@@ -139,6 +140,10 @@ private class FXSceneEditor extends hide.comp.SceneEditor {
 		menu.push({
 			label: "Other",
 			menu: allTypes
+		});
+		menu.unshift({
+			label : "Recents",
+			menu : recents,
 		});
 		return menu;
 	}

--- a/hide/view/Prefab.hx
+++ b/hide/view/Prefab.hx
@@ -184,6 +184,7 @@ private class PrefabSceneEditor extends hide.comp.SceneEditor {
 
 	override function getNewContextMenu(current: PrefabElement, ?onMake: PrefabElement->Void=null, ?groupByType = true ) {
 		var newItems = super.getNewContextMenu(current, onMake, groupByType);
+		var recents = getNewRecentContextMenu(current, onMake);
 
 		function setup(p : PrefabElement) {
 			autoName(p);
@@ -252,6 +253,10 @@ private class PrefabSceneEditor extends hide.comp.SceneEditor {
 			});
 		};
 		addNewInstances();
+		newItems.unshift({
+			label : "Recents",
+			menu : recents,
+		});
 		return newItems;
 	}
 


### PR DESCRIPTION
The `Recents` submenu is now at the top of the `New...` submenu in Fx and prefab views

## Prefab/l3d

Before
![image](https://user-images.githubusercontent.com/22801009/126762681-02da508a-f881-4018-a3c1-cf13ffa57ed3.png)
After
![image](https://user-images.githubusercontent.com/22801009/126762585-845366f9-b5e0-4385-bbd3-40d5fbc04a1e.png)

## Fx editor
Before
![image](https://user-images.githubusercontent.com/22801009/126762717-62fd4867-6dd3-48a1-903b-6ef163ddc720.png)
After
![image](https://user-images.githubusercontent.com/22801009/126762604-615aaaa7-a0fe-47ac-89d7-e30ee1f849f9.png)
