### PR TITLE
Fix Prefab view registering non existent keys

### DIFF
--- a/hide/view/Prefab.hx
+++ b/hide/view/Prefab.hx
@@ -518,7 +518,8 @@ class Prefab extends FileView {
 				case Toggle(f):
 					var toggle = tools.addToggle(tool.icon, tool.title + shortcut, f);
 					el = toggle.element;
-					keys.register("sceneeditor." + tool.id, () -> toggle.toggle(!toggle.isDown()));
+					if( key != null )
+						keys.register("sceneeditor." + tool.id, () -> toggle.toggle(!toggle.isDown()));
 					if (tool.rightClick != null)
 						toggle.rightClick(tool.rightClick);
 				case Color(f):


### PR DESCRIPTION
Keys will no longer trace "Key not defined" in the console