### PR TITLE
Fix tileselector closing when dragging outside it

### DIFF
--- a/hide/comp/Modal.hx
+++ b/hide/comp/Modal.hx
@@ -2,17 +2,35 @@ package hide.comp;
 
 class Modal extends Component {
 
-    public var content(default,null) : Element;
+	public var content(default,null) : Element;
+	var downTarget : Dynamic;
+	var upTarget : Dynamic;
 
-    public function new(?parent,?el) {
-        super(parent,el);
-        element.addClass('hide-modal');
-        element.on("click dblclick keydown keyup keypressed mousedown mouseup mousewheel",function(e) e.stopPropagation());
-        content = new Element("<div class='content'></div>").appendTo(element);
-    }
+	public function new(?parent,?el) {
+		super(parent,el);
+		element.addClass('hide-modal');
+		element.on("click dblclick keydown keyup keypressed mousedown mouseup mousewheel",function(e) e.stopPropagation());
+		content = new Element("<div class='content'></div>").appendTo(element);
 
-    public function close() {
-        element.remove();
-    }
+		var exterior = [element[0], content[0]];
+		element[0].addEventListener("mousedown", function(e) {
+			downTarget = e.target;
+		}, true);
+		element[0].addEventListener("mouseup", function(e) {
+			upTarget = e.target;
+		}, true);
+		element.on("click", function(e : js.jquery.Event) {
+			if( exterior.contains(downTarget) && exterior.contains(upTarget) ) {
+				modalClick(e);
+			}
+		});
+	}
+
+	public dynamic function modalClick(e: js.jquery.Event) {
+	}
+
+	public function close() {
+		element.remove();
+	}
 
 }

--- a/hide/comp/cdb/Cell.hx
+++ b/hide/comp/cdb/Cell.hx
@@ -709,7 +709,7 @@ class Cell extends Component {
 			});
 		case TTilePos:
 			var modal = new hide.comp.Modal(element);
-			modal.element.click(function(_) closeEdit());
+			modal.modalClick = function(_) closeEdit();
 
 			var t : cdb.Types.TilePos = currentValue;
 			var file = t == null ? null : t.file;


### PR DESCRIPTION
Until now clicking/dragging the mouse from the inside of the tileselector and releasing outside would close it

This also adds the dynamic function `Modal.modalClick` which is called on the modal's element click event, but only if the corresponding mousedown was fired directly on the modal's root element or root content

Also make Modal.hx use tabs instead of spaces