### PR TITLE
Cache image dimensions for cdb cell displays

### DIFF
--- a/hide/comp/cdb/Cell.hx
+++ b/hide/comp/cdb/Cell.hx
@@ -520,7 +520,6 @@ class Cell extends Component {
 		}
 	}
 
-
 	public function isTextInput() {
 		return switch( column.type ) {
 		case TString if( column.kind == Script ):


### PR DESCRIPTION
There should now be one less reflow for each image on a cdb table after the first time loading.

This should be quite noticeable for very large sheets.