### PR TITLE
Add getHideProps with allowParent -> false to prefab

### DIFF
--- a/hrt/prefab/Library.hx
+++ b/hrt/prefab/Library.hx
@@ -70,6 +70,12 @@ class Library extends Prefab {
 		return registeredExtensions.get(extension);
 	}
 
+	#if editor
+	override function getHideProps() : HideProps {
+		return { icon : "sitemap", name : "Prefab", allowParent: _ -> false};
+	}
+	#end
+
 	static var _ = Library.register("prefab", Library, "prefab");
 
 }

--- a/hrt/prefab/l3d/Level3D.hx
+++ b/hrt/prefab/l3d/Level3D.hx
@@ -8,5 +8,11 @@ class Level3D extends hrt.prefab.Library {
 		type = "level3d";
 	}
 
+	#if editor
+	override function getHideProps() : HideProps {
+		return { icon : "sitemap", name : "Level3D", allowParent: _ -> false};
+	}
+	#end
+
 	static var _ = Library.register("level3d", Level3D, "l3d");
 }


### PR DESCRIPTION
Before this prefab and level3d would show up as "Unknown" in the New -> Other context menu

This adds a getHideProps function similar to hrt.prefab.fx.Fx