### PR TITLE
Major Emitter optimizations

### DIFF
--- a/hide/view/FXEditor.hx
+++ b/hide/view/FXEditor.hx
@@ -996,10 +996,10 @@ class FXEditor extends FileView {
 			updateExpanded();
 		});
 		var dopesheet = trackEl.find(".dopesheet");
-		var evaluator = new hrt.prefab.fx.Evaluator(new hxd.Rand(0));
+		var evaluator = new hrt.prefab.fx.Evaluator();
 
 		function getKeyColor(key) {
-			return evaluator.getVector(Curve.getColorValue(curves), key.time);
+			return evaluator.getVector(Curve.getColorValue(curves), key.time, new h3d.Vector());
 		}
 
 		function dragKey(from: hide.comp.CurveEditor, prevTime: Float, newTime: Float) {

--- a/hrt/prefab/DynamicShader.hx
+++ b/hrt/prefab/DynamicShader.hx
@@ -71,7 +71,7 @@ class DynamicShader extends Shader {
 		if(StringTools.endsWith(path, ".hx")) path = path.substr(0, -3);
 		var cpath = path.split("/").join(".");
 		var cl = cast Type.resolveClass(cpath);
-		if( cl == null && !opt ) throw "Missing shader class"+cpath;
+		if( cl == null && !opt ) throw "Missing shader class "+cpath;
 		return cl;
 	}
 

--- a/hrt/prefab/fx/BaseFX.hx
+++ b/hrt/prefab/fx/BaseFX.hx
@@ -175,7 +175,7 @@ class BaseFX extends hrt.prefab.Library {
 
 		for(shCtx in ctx.shared.getContexts(elt)) {
 			if(shCtx.custom == null) continue;
-			var anim = Std.isOfType(shCtx.custom,hxsl.DynamicShader) ? new ShaderDynAnimation(new hxd.Rand(0)) : new ShaderAnimation(new hxd.Rand(0));
+			var anim = Std.isOfType(shCtx.custom,hxsl.DynamicShader) ? new ShaderDynAnimation() : new ShaderAnimation();
 			anim.shader = shCtx.custom;
 			anim.params = makeShaderParams(ctx, shader);
 			anims.push(anim);

--- a/hrt/prefab/fx/BaseFX.hx
+++ b/hrt/prefab/fx/BaseFX.hx
@@ -46,6 +46,7 @@ class ShaderAnimation extends Evaluator {
 
 class ShaderDynAnimation extends ShaderAnimation {
 
+	static var tmpVec = new h3d.Vector();
 	override function setTime(time: Float) {
 		var shader : hxsl.DynamicShader = cast shader;
 		for(param in params) {
@@ -61,8 +62,8 @@ class ShaderDynAnimation extends ShaderAnimation {
 					var val = getFloat(param.value, time) >= 0.5;
 					shader.setParamValue(v, val);
 				case TVec(_, VFloat):
-					var val = getVector(param.value, time);
-					shader.setParamValue(v, val);
+					getVector(param.value, time, tmpVec);
+					shader.setParamValue(v, tmpVec);
 				default:
 			}
 		}

--- a/hrt/prefab/fx/Emitter.hx
+++ b/hrt/prefab/fx/Emitter.hx
@@ -71,147 +71,33 @@ class InstanceDef {
 }
 
 typedef ShaderAnims = Array<ShaderAnimation>;
-
-@:publicFields @:struct
-class SVector3 {
-	var x : Float;
-	var y : Float;
-	var z : Float;
-
-	inline function toVector() {
-		return new h3d.Vector(x, y, z);
-	}
-	inline function loadVector(v: h3d.Vector) {
-		this.x = v.x;
-		this.y = v.y;
-		this.z = v.z;
-	}
-}
-
-@:publicFields @:struct
-class SVector4 {
-	var x : Float;
-	var y : Float;
-	var z : Float;
-	var w : Float;
-
-	inline function toQuat() {
-		return new h3d.Quat(x, y, z, w);
-	}
-	inline function loadQuat(q: h3d.Quat) {
-		this.x = q.x;
-		this.y = q.y;
-		this.z = q.z;
-		this.w = q.w;
-	}
-
-	inline function toVector() {
-		return new h3d.Vector(x, y, z, w);
-	}
-	inline function loadVector(v: h3d.Vector) {
-		this.x = v.x;
-		this.y = v.y;
-		this.z = v.z;
-		this.w = v.w;
-	}
-}
-
-
-@:publicFields @:struct
-class SMatrix3 {
-	var _11 : Float;
-	var _12 : Float;
-	var _13 : Float;
-	var _21 : Float;
-	var _22 : Float;
-	var _23 : Float;
-	var _31 : Float;
-	var _32 : Float;
-	var _33 : Float;
-
-	inline function toMatrix() {
-		var m = new h3d.Matrix();
-		m._11 = _11; m._12 = _12; m._13 = _13;
-		m._21 = _21; m._22 = _22; m._23 = _23;
-		m._31 = _31; m._32 = _32; m._33 = _33;
-		return m;
-	}
-
-	inline function load(m : h3d.Matrix) {
-		_11 = m._11; _12 = m._12; _13 = m._13;
-		_21 = m._21; _22 = m._22; _23 = m._23;
-		_31 = m._31; _32 = m._32; _33 = m._33;
-	}
-}
-
-
-@:publicFields @:struct
-class SMatrix4 {
-	var _11 : Float;
-	var _12 : Float;
-	var _13 : Float;
-	var _14 : Float;
-	var _21 : Float;
-	var _22 : Float;
-	var _23 : Float;
-	var _24 : Float;
-	var _31 : Float;
-	var _32 : Float;
-	var _33 : Float;
-	var _34 : Float;
-	var _41 : Float;
-	var _42 : Float;
-	var _43 : Float;
-	var _44 : Float;
-
-	public inline function getPosition() {
-		var v = new h3d.Vector();
-		v.set(_41,_42,_43,_44);
-		return v;
-	}
-
-	inline function toMatrix() {
-		var m = new h3d.Matrix();
-		m._11 = _11; m._12 = _12; m._13 = _13; m._14 = _14; 
-		m._21 = _21; m._22 = _22; m._23 = _23; m._24 = _24; 
-		m._31 = _31; m._32 = _32; m._33 = _33; m._34 = _34; 
-		m._41 = _41; m._42 = _42; m._43 = _43; m._44 = _44; 
-		return m;
-	}
-
-	inline function load(m : h3d.Matrix) {
-		_11 = m._11; _12 = m._12; _13 = m._13; _14 = m._14;
-		_21 = m._21; _22 = m._22; _23 = m._23; _24 = m._24;
-		_31 = m._31; _32 = m._32; _33 = m._33; _34 = m._34;
-		_41 = m._41; _42 = m._42; _43 = m._43; _44 = m._44;
-	}
-}
+typedef Single = Float;
 
 @:allow(hrt.prefab.fx.EmitterObject) 
 @:struct
 private class ParticleInstance  {
 	var emitter : EmitterObject;
 
-	public var idx : Int;
-	public var x : Float;
-	public var y : Float;
-	public var z : Float;
-	public var scaleX : Float;
-	public var scaleY : Float;
-	public var scaleZ : Float;
+	public var x : Single;
+	public var y : Single;
+	public var z : Single;
+	public var scaleX : Single;
+	public var scaleY : Single;
+	public var scaleZ : Single;
 
 	@:packed public var speedAccumulation(default, never) : SVector3;
 	@:packed public var qRot(default, never) : SVector4;
 	@:packed public var absPos(default, never) : SMatrix4;  // Needed for sortZ
 	@:packed public var emitOrientation(default, never) : SMatrix3;
-	public var colorMult : h3d.Vector;  // TODO: Could be recalc using this.random
 
-	public var life : Float;
-	public var lifeTime : Float;
-	public var random : Float;
-	public var distToCam : Float;
-	public var startTime : Float;
-	public var startFrame : Int;
+	public var colorMult : Int;
+	public var idx : hxd.impl.UInt16;
+	public var startFrame : hxd.impl.UInt16;
+	public var life : Single;
+	public var lifeTime : Single;
+	public var random : Single;
+	public var distToCam : Single;
+	public var startTime : Single;
 	public var allocated : Bool;
 
 	public function new() {
@@ -225,6 +111,7 @@ private class ParticleInstance  {
 		scaleY = 1.0;
 		scaleZ = 1.0;
 
+		colorMult = -1;
 		speedAccumulation.loadVector(new h3d.Vector());
 		life = 0;
 		lifeTime = 0;
@@ -637,12 +524,12 @@ class EmitterObject extends h3d.scene.Object {
 
 				if(useRandomColor) {
 					if (useRandomGradient) {
-						part.colorMult = Gradient.evalData(randomGradient, random.rand());
+						part.colorMult = Gradient.evalData(randomGradient, random.rand()).toColor();
 					}
 					else {
 						var col = new h3d.Vector();
 						col.lerp(randomColor1, randomColor2, random.rand());
-						part.colorMult = col;
+						part.colorMult = col.toColor();
 					}
 				}
 
@@ -1017,7 +904,7 @@ class EmitterObject extends h3d.scene.Object {
 			baseEmitterShader.random = p.random;
 
 			if(colorMultShader != null)
-				colorMultShader.color = p.colorMult;
+				colorMultShader.color.setColor(p.colorMult);
 			batch.emitInstance();
 			// p = p.next;
 			// ++i;
@@ -1876,3 +1763,110 @@ class Emitter extends Object3D {
 	static var _ = Library.register("emitter", Emitter);
 
 }
+
+#if hl
+
+@:publicFields @:struct
+class SVector3 {
+	var x : Single;
+	var y : Single;
+	var z : Single;
+
+	inline function toVector() {
+		return new h3d.Vector(x, y, z);
+	}
+	inline function loadVector(v: h3d.Vector) {
+		this.x = v.x;
+		this.y = v.y;
+		this.z = v.z;
+	}
+}
+
+@:publicFields @:struct
+class SVector4 {
+	var x : Single;
+	var y : Single;
+	var z : Single;
+	var w : Single;
+
+	inline function toQuat() {
+		return new h3d.Quat(x, y, z, w);
+	}
+	inline function loadQuat(q: h3d.Quat) {
+		this.x = q.x;
+		this.y = q.y;
+		this.z = q.z;
+		this.w = q.w;
+	}
+
+	inline function toVector() {
+		return new h3d.Vector(x, y, z, w);
+	}
+	inline function loadVector(v: h3d.Vector) {
+		this.x = v.x;
+		this.y = v.y;
+		this.z = v.z;
+		this.w = v.w;
+	}
+}
+
+
+@:publicFields @:struct
+class SMatrix3 {
+	var _11 : Single;
+	var _12 : Single;
+	var _13 : Single;
+	var _21 : Single;
+	var _22 : Single;
+	var _23 : Single;
+	var _31 : Single;
+	var _32 : Single;
+	var _33 : Single;
+
+	inline function toMatrix() {
+		var m = new h3d.Matrix();
+		m._11 = _11; m._12 = _12; m._13 = _13;
+		m._21 = _21; m._22 = _22; m._23 = _23;
+		m._31 = _31; m._32 = _32; m._33 = _33;
+		return m;
+	}
+
+	inline function load(m : h3d.Matrix) {
+		_11 = m._11; _12 = m._12; _13 = m._13;
+		_21 = m._21; _22 = m._22; _23 = m._23;
+		_31 = m._31; _32 = m._32; _33 = m._33;
+	}
+}
+
+
+@:publicFields @:struct
+class SMatrix4 {
+	var _11 : Single; var _12 : Single; var _13 : Single; var _14 : Single;
+	var _21 : Single; var _22 : Single; var _23 : Single; var _24 : Single;
+	var _31 : Single; var _32 : Single; var _33 : Single; var _34 : Single;
+	var _41 : Single; var _42 : Single; var _43 : Single; var _44 : Single;
+
+	public inline function getPosition() {
+		var v = new h3d.Vector();
+		v.set(_41,_42,_43,_44);
+		return v;
+	}
+
+	inline function toMatrix() {
+		var m = new h3d.Matrix();
+		m._11 = _11; m._12 = _12; m._13 = _13; m._14 = _14; 
+		m._21 = _21; m._22 = _22; m._23 = _23; m._24 = _24; 
+		m._31 = _31; m._32 = _32; m._33 = _33; m._34 = _34; 
+		m._41 = _41; m._42 = _42; m._43 = _43; m._44 = _44; 
+		return m;
+	}
+
+	inline function load(m : h3d.Matrix) {
+		_11 = m._11; _12 = m._12; _13 = m._13; _14 = m._14;
+		_21 = m._21; _22 = m._22; _23 = m._23; _24 = m._24;
+		_31 = m._31; _32 = m._32; _33 = m._33; _34 = m._34;
+		_41 = m._41; _42 = m._42; _43 = m._43; _44 = m._44;
+	}
+}
+
+#end

--- a/hrt/prefab/fx/Emitter.hx
+++ b/hrt/prefab/fx/Emitter.hx
@@ -843,8 +843,6 @@ class EmitterObject extends h3d.scene.Object {
 			invTransform.load(parent.getInvPos());
 		}
 
-		//vecPool.begin();
-
 		if( enable ) {
 			switch emitType {
 				case Infinity:
@@ -1015,7 +1013,7 @@ class EmitterObject extends h3d.scene.Object {
 			// so emitter shape can be transformed (especially scaled) without affecting children
 			case Local : parentTransform.load(parent.getAbsPos());
 			case World : parentTransform.load(getScene().getAbsPos());
-			// TODO optim: set to null if identity to skip multiply in particle updates
+			// Optim: set to null if identity to skip multiply in particle updates
 		}
 
 		var prev : ParticleInstance = null;
@@ -1069,14 +1067,8 @@ class EmitterObject extends h3d.scene.Object {
 		time = time * speedFactor + warmUpTime;
 		if(hxd.Math.abs(time - curTime) < 1e-6) {  // Time imprecisions can occur during accumulation
 			updateAlignment();
-			for(i in 0...numInstances) {
-				//if(!p.allocated) throw "!";
+			for(i in 0...numInstances)
 				particles[i].updateAbsPos(this);
-			}
-			// var p = particles;
-			// while(p != null) {
-			// 	p = p.next;
-			// }
 			updateMeshBatch();
 			return;
 		}

--- a/hrt/prefab/fx/Emitter.hx
+++ b/hrt/prefab/fx/Emitter.hx
@@ -476,6 +476,7 @@ class EmitterObject extends h3d.scene.Object {
 	}
 
 	public function reset() {
+		numInstances = 0;
 		enable = true;
 		random.init(randomSeed);
 		curTime = 0.0;
@@ -485,6 +486,7 @@ class EmitterObject extends h3d.scene.Object {
 
 		randomValues = [for(i in 0...(maxCount * randSlots)) random.srand()];
 		evaluator = new Evaluator(randomValues, randSlots);
+		listHead = null;
 
 		particles = #if hl hl.CArray.alloc(ParticleInstance, maxCount) #else [for(i in 0...maxCount) new ParticleInstance()] #end;
 		for(p in particles)

--- a/hrt/prefab/fx/Emitter.hx
+++ b/hrt/prefab/fx/Emitter.hx
@@ -371,7 +371,7 @@ private class ParticleInstance  {
 		if(emitter.emitOrientation == Speed && tmpSpeed.lengthSq() > 0.01) {
 			var qRot = qRot.toQuat();
 			inline qRot.initDirection(tmpSpeed);
-			this.qRot.load(qRot);
+			this.qRot.loadQuat(qRot);
 		}
 	}
 }
@@ -694,7 +694,7 @@ class EmitterObject extends h3d.scene.Object {
 						tmpOffset.transform(tmpMat);
 						part.setPosition(tmpOffset.x, tmpOffset.y, tmpOffset.z);
 						tmpQuat.multiply(emitterQuat, tmpQuat);
-						part.qRot.load(tmpQuat);
+						part.qRot.loadQuat(tmpQuat);
 						tmpQuat.toMatrix(tmpMat2);
 						part.emitOrientation.load(tmpMat2);
 					case World:
@@ -708,7 +708,7 @@ class EmitterObject extends h3d.scene.Object {
 						emitterQuat.initRotateMatrix(tmpMat);
 						emitterQuat.normalize();
 						tmpQuat.multiply(tmpQuat, emitterQuat);
-						part.qRot.load(tmpQuat);
+						part.qRot.loadQuat(tmpQuat);
 						tmpQuat.toMatrix(tmpMat2);
 						part.emitOrientation.load(tmpMat2);
 						part.setScale(worldScale.x, worldScale.y, worldScale.z);
@@ -1873,7 +1873,15 @@ class SVector4 {
 	inline function toQuat() {
 		return new h3d.Quat(x, y, z, w);
 	}
-	inline function load(q: { x: Float, y: Float, z: Float, w: Float }) {
+	
+	inline function load(v: h3d.Vector) {
+		this.x = v.x;
+		this.y = v.y;
+		this.z = v.z;
+		this.w = v.w;
+	}
+
+	inline function loadQuat(q: h3d.Quat) {
 		this.x = q.x;
 		this.y = q.y;
 		this.z = q.z;

--- a/hrt/prefab/fx/Emitter.hx
+++ b/hrt/prefab/fx/Emitter.hx
@@ -70,12 +70,6 @@ class InstanceDef {
 	public function new() { }
 }
 
-typedef EmitterTrail = {
-	particle : ParticleInstance,
-	trail : h3d.scene.Trail,
-	timeBeforeDeath : Float
-}
-
 typedef ShaderAnims = Array<ShaderAnimation>;
 
 @:allow(hrt.prefab.fx.EmitterObject)
@@ -397,9 +391,7 @@ class EmitterObject extends h3d.scene.Object {
 	// OBJECTS
 	public var particleTemplate : hrt.prefab.Object3D;
 	public var subEmitterTemplate : Emitter;
-	public var trailTemplate : hrt.prefab.l3d.Trail;
 	public var subEmitters : Array<EmitterObject> = [];
-	public var trails : Array<EmitterTrail> = [];
 	// LIFE
 	public var lifeTime = 2.0;
 	public var lifeTimeRand = 0.0;
@@ -490,10 +482,6 @@ class EmitterObject extends h3d.scene.Object {
 			s.remove();
 		}
 		subEmitters = [];
-		for( t in trails ) {
-			t.trail.remove();
-		}
-		trails = [];
 	}
 
 	override function onRemove() {
@@ -515,15 +503,6 @@ class EmitterObject extends h3d.scene.Object {
 
 	var tmpCtx : hrt.prefab.Context;
 	function disposeInstance(p: ParticleInstance) {
-
-		// TRAIL
-		for( t in trails ) {
-			if( t.particle == p ) {
-				t.particle = null;
-				break;
-			}
-		}
-
 		p.next = pool;
 		p.dispose();
 		pool = p;
@@ -1368,9 +1347,6 @@ class Emitter extends Object3D {
 		// SUB-EMITTER
 		var subEmitterTemplate : Emitter = cast children.find( p -> p.enabled && Std.downcast(p, Emitter) != null && p.to(Object3D).visible);
 		emitterObj.subEmitterTemplate = subEmitterTemplate;
-		// TRAIL
-		var trailTemplate : hrt.prefab.l3d.Trail = cast children.find( p -> p.enabled && Std.isOfType(p, hrt.prefab.l3d.Trail) && p.to(Object3D).visible);
-		emitterObj.trailTemplate = trailTemplate;
 		// RANDOM
 		emitterObj.seedGroup 			= 	getParamVal("seedGroup");
 		// LIFE

--- a/hrt/prefab/fx/Emitter.hx
+++ b/hrt/prefab/fx/Emitter.hx
@@ -117,8 +117,7 @@ class SVector4 {
 }
 
 
-@:publicFields
-@:struct
+@:publicFields @:struct
 class SMatrix3 {
 	var _11 : Float;
 	var _12 : Float;
@@ -132,34 +131,21 @@ class SMatrix3 {
 
 	inline function toMatrix() {
 		var m = new h3d.Matrix();
-		m._11 = _11;
-		m._12 = _12;
-		m._13 = _13;
-		m._21 = _21;
-		m._22 = _22;
-		m._23 = _23;
-		m._31 = _31;
-		m._32 = _32;
-		m._33 = _33;
+		m._11 = _11; m._12 = _12; m._13 = _13;
+		m._21 = _21; m._22 = _22; m._23 = _23;
+		m._31 = _31; m._32 = _32; m._33 = _33;
 		return m;
 	}
 
 	inline function load(m : h3d.Matrix) {
-		_11 = m._11;
-		_12 = m._12;
-		_13 = m._13;
-		_21 = m._21;
-		_22 = m._22;
-		_23 = m._23;
-		_31 = m._31;
-		_32 = m._32;
-		_33 = m._33;
+		_11 = m._11; _12 = m._12; _13 = m._13;
+		_21 = m._21; _22 = m._22; _23 = m._23;
+		_31 = m._31; _32 = m._32; _33 = m._33;
 	}
 }
 
 
-@:publicFields
-@:struct
+@:publicFields @:struct
 class SMatrix4 {
 	var _11 : Float;
 	var _12 : Float;
@@ -186,46 +172,22 @@ class SMatrix4 {
 
 	inline function toMatrix() {
 		var m = new h3d.Matrix();
-		m._11 = _11;
-		m._12 = _12;
-		m._13 = _13;
-		m._14 = _14;
-		m._21 = _21;
-		m._22 = _22;
-		m._23 = _23;
-		m._24 = _24;
-		m._31 = _31;
-		m._32 = _32;
-		m._33 = _33;
-		m._34 = _34;
-		m._41 = _41;
-		m._42 = _42;
-		m._43 = _43;
-		m._44 = _44;
+		m._11 = _11; m._12 = _12; m._13 = _13; m._14 = _14; 
+		m._21 = _21; m._22 = _22; m._23 = _23; m._24 = _24; 
+		m._31 = _31; m._32 = _32; m._33 = _33; m._34 = _34; 
+		m._41 = _41; m._42 = _42; m._43 = _43; m._44 = _44; 
 		return m;
 	}
 
 	inline function load(m : h3d.Matrix) {
-		_11 = m._11;
-		_12 = m._12;
-		_13 = m._13;
-		_14 = m._14;
-		_21 = m._21;
-		_22 = m._22;
-		_23 = m._23;
-		_24 = m._24;
-		_31 = m._31;
-		_32 = m._32;
-		_33 = m._33;
-		_34 = m._34;
-		_41 = m._41;
-		_42 = m._42;
-		_43 = m._43;
-		_44 = m._44;
+		_11 = m._11; _12 = m._12; _13 = m._13; _14 = m._14;
+		_21 = m._21; _22 = m._22; _23 = m._23; _24 = m._24;
+		_31 = m._31; _32 = m._32; _33 = m._33; _34 = m._34;
+		_41 = m._41; _42 = m._42; _43 = m._43; _44 = m._44;
 	}
 }
 
-@:allow(hrt.prefab.fx.EmitterObject)
+@:allow(hrt.prefab.fx.EmitterObject) 
 @:struct
 private class ParticleInstance  {
 	var emitter : EmitterObject;
@@ -238,10 +200,10 @@ private class ParticleInstance  {
 	public var scaleY : Float;
 	public var scaleZ : Float;
 
-	@:packed public var speedAccumulation : SVector3;
-	@:packed public var qRot : SVector4;
-	@:packed public var absPos : SMatrix4;  // Needed for sortZ
-	@:packed public var emitOrientation : SMatrix3;
+	@:packed public var speedAccumulation(default, never) : SVector3;
+	@:packed public var qRot(default, never) : SVector4;
+	@:packed public var absPos(default, never) : SMatrix4;  // Needed for sortZ
+	@:packed public var emitOrientation(default, never) : SMatrix3;
 	public var colorMult : h3d.Vector;  // TODO: Could be recalc using this.random
 
 	public var life : Float;
@@ -848,7 +810,8 @@ class EmitterObject extends h3d.scene.Object {
 
 			if( meshPrim != null ) {
 				batch = new h3d.scene.MeshBatch(meshPrim, mesh.material, this);
-				batch.name = "batch";
+				batch.name = "emitter";
+				batch.calcBounds = false;
 			}
 
 			/*trace("Shaders for " + this.name);

--- a/hrt/prefab/fx/Evaluator.hx
+++ b/hrt/prefab/fx/Evaluator.hx
@@ -11,7 +11,6 @@ class Evaluator {
 
 	inline function getRandom(pidx: Int, ridx: Int) {
 		var i = pidx * stride + ridx;
-		if(i > randValues.length) throw "assert";
 		return randValues[i];
 	}
 

--- a/hrt/prefab/fx/Evaluator.hx
+++ b/hrt/prefab/fx/Evaluator.hx
@@ -1,38 +1,46 @@
 package hrt.prefab.fx;
 
-class VecPool {
-	var vecPool : Array<h3d.Vector> = null;
-	var vecPoolSize = 0;
+// class VecPool {
+// 	var vecPool : Array<h3d.Vector> = null;
+// 	var vecPoolSize = 0;
 
-	public function new() { }
+// 	public function new() { }
 
-	public function begin() {
-		if(vecPool == null)
-			vecPool = [];
-		vecPoolSize = 0;
-	}
+// 	public function begin() {
+// 		if(vecPool == null)
+// 			vecPool = [];
+// 		vecPoolSize = 0;
+// 	}
 
-	public function get() {
-		var vec = null;
-		if(vecPoolSize < vecPool.length)
-			vec = vecPool[vecPoolSize++];
-		else {
-			vec = new h3d.Vector();
-			vecPool.push(vec);
-		}
-		return vec;
-	}
-}
+// 	public function get() {
+// 		var vec = null;
+// 		if(vecPoolSize < vecPool.length)
+// 			vec = vecPool[vecPoolSize++];
+// 		else {
+// 			vec = new h3d.Vector();
+// 			vecPool.push(vec);
+// 		}
+// 		return vec;
+// 	}
+// }
 
 class Evaluator {
 	var randValues : Array<Float> = [];
 	var random: hxd.Rand;
-	public var vecPool : VecPool;
+	// public var vecPool : VecPool;
 
 	public function new(random: hxd.Rand) {
 		this.random = random;
 	}
 
+	inline function getRandom(idx) {
+		var len = randValues.length;
+		while(idx >= len) {
+			randValues.push(random.srand());
+			++len;
+		}
+		return randValues[idx];
+	}
 	public function getFloat(val: Value, time: Float) : Float {
 		if(val == null)
 			return 0.0;
@@ -43,19 +51,11 @@ class Evaluator {
 			case VCurve(c): return c.getVal(time);
 			case VCurveScale(c, scale): return c.getVal(time) * scale;
 			case VRandom(idx, scale):
-				var len = randValues.length;
-				while(idx >= len) {
-					randValues.push(random.srand());
-					++len;
-				}
-				return randValues[idx] * getFloat(scale, time);
+				return getRandom(idx) * getFloat(scale, time);
 			case VRandomScale(idx, scale):
-				var len = randValues.length;
-				while(idx >= len) {
-					randValues.push(random.srand());
-					++len;
-				}
-				return randValues[idx] * scale;
+				return getRandom(idx) * scale;
+			case VAddRandCurve(cst, ridx, rscale, c):
+				return (cst + getRandom(ridx) * rscale) * c.getVal(time);
 			case VMult(a, b):
 				return getFloat(a, time) * getFloat(b, time);
 			case VAdd(a, b):
@@ -81,14 +81,13 @@ class Evaluator {
 		return 0.0;
 	}
 
-	public function getVector(v: Value, time: Float, ?vec: h3d.Vector) : h3d.Vector {
-		if(vec == null)
-			vec = vecPool != null ? vecPool.get() : new h3d.Vector();
+	public function getVector(v: Value, time: Float, vec: h3d.Vector) {
 		switch(v) {
 			case VMult(a, b):
-				var av = getVector(a, time);
-				var bv = getVector(b, time);
-				vec.set(av.x * bv.x, av.y * bv.y, av.z * bv.z, av.w * bv.w);
+				throw "need optimization";
+				// var av = getVector(a, time);
+				// var bv = getVector(b, time);
+				// vec.set(av.x * bv.x, av.y * bv.y, av.z * bv.z, av.w * bv.w);
 			case VVector(x, y, z, null):
 				vec.set(getFloat(x, time), getFloat(y, time), getFloat(z, time), 1.0);
 			case VVector(x, y, z, w):

--- a/hrt/prefab/fx/FX.hx
+++ b/hrt/prefab/fx/FX.hx
@@ -52,8 +52,6 @@ class FXAnimation extends h3d.scene.Object {
 		events = initEvents(root, ctx);
 		var root = def.getFXRoot(ctx, def);
 		initConstraints(ctx, root != null ? root : def);
-		// for(s in shaderAnims)
-		// 	s.vecPool = vecPool;
 	}
 
 	override function onRemove() {
@@ -144,7 +142,6 @@ class FXAnimation extends h3d.scene.Object {
 	public function setTime( time : Float, fullSync=true ) {
 		this.localTime = time;
 		if(fullSync) {
-			//vecPool.begin();
 			if(objAnims != null) {
 				for(anim in objAnims) {
 					if(anim.scale != null || anim.rotation != null || anim.position != null) {

--- a/hrt/prefab/fx/FX.hx
+++ b/hrt/prefab/fx/FX.hx
@@ -27,7 +27,7 @@ class FXAnimation extends h3d.scene.Object {
 	public var shaderAnims : Array<ShaderAnimation> = [];
 	public var constraints : Array<hrt.prefab.l3d.Constraint>;
 
-	public var vecPool = new Evaluator.VecPool();
+	//public var vecPool = new Evaluator.VecPool();
 	var evaluator : Evaluator;
 	var parentFX : FXAnimation;
 	var random : hxd.Rand;
@@ -40,7 +40,7 @@ class FXAnimation extends h3d.scene.Object {
 		randSeed = #if editor 0 #else Std.random(0xFFFFFF) #end;
 		random = new hxd.Rand(randSeed);
 		evaluator = new Evaluator(random);
-		evaluator.vecPool = vecPool;
+		//evaluator.vecPool = vecPool;
 		name = "FXAnimation";
 		inheritCulled = true;
 	}
@@ -54,8 +54,8 @@ class FXAnimation extends h3d.scene.Object {
 		events = initEvents(root, ctx);
 		var root = def.getFXRoot(ctx, def);
 		initConstraints(ctx, root != null ? root : def);
-		for(s in shaderAnims)
-			s.vecPool = vecPool;
+		// for(s in shaderAnims)
+		// 	s.vecPool = vecPool;
 	}
 
 	override function onRemove() {
@@ -146,7 +146,7 @@ class FXAnimation extends h3d.scene.Object {
 	public function setTime( time : Float, fullSync=true ) {
 		this.localTime = time;
 		if(fullSync) {
-			vecPool.begin();
+			//vecPool.begin();
 			if(objAnims != null) {
 				for(anim in objAnims) {
 					if(anim.scale != null || anim.rotation != null || anim.position != null) {

--- a/hrt/prefab/fx/FX.hx
+++ b/hrt/prefab/fx/FX.hx
@@ -27,7 +27,6 @@ class FXAnimation extends h3d.scene.Object {
 	public var shaderAnims : Array<ShaderAnimation> = [];
 	public var constraints : Array<hrt.prefab.l3d.Constraint>;
 
-	//public var vecPool = new Evaluator.VecPool();
 	var evaluator : Evaluator;
 	var parentFX : FXAnimation;
 	var random : hxd.Rand;
@@ -39,8 +38,7 @@ class FXAnimation extends h3d.scene.Object {
 		super(parent);
 		randSeed = #if editor 0 #else Std.random(0xFFFFFF) #end;
 		random = new hxd.Rand(randSeed);
-		evaluator = new Evaluator(random);
-		//evaluator.vecPool = vecPool;
+		evaluator = new Evaluator();
 		name = "FXAnimation";
 		inheritCulled = true;
 	}

--- a/hrt/prefab/fx/FX2D.hx
+++ b/hrt/prefab/fx/FX2D.hx
@@ -28,7 +28,7 @@ class FX2DAnimation extends h2d.Object {
 	public function new(?parent) {
 		super(parent);
 		random = new hxd.Rand(Std.random(0xFFFFFF));
-		evaluator = new Evaluator(random);
+		evaluator = new Evaluator();
 		name = "FX2DAnimation";
 		setTime(0);
 	}

--- a/hrt/prefab/fx/FX2D.hx
+++ b/hrt/prefab/fx/FX2D.hx
@@ -75,26 +75,27 @@ class FX2DAnimation extends h2d.Object {
 	}
 
 
+	static var tmpPt = new h3d.Vector();
 	public function setTime( time : Float ) {
 
 		this.localTime = time;
 
 		for(anim in objects) {
 			if(anim.scale != null) {
-				var scale = evaluator.getVector(anim.scale, time);
-				anim.obj2d.scaleX = scale.x;
-				anim.obj2d.scaleY = scale.y;
+				evaluator.getVector(anim.scale, time, tmpPt);
+				anim.obj2d.scaleX = tmpPt.x;
+				anim.obj2d.scaleY = tmpPt.y;
 			}
 
 			if(anim.rotation != null) {
-				var rotation = evaluator.getVector(anim.rotation, time);
-				anim.obj2d.rotation = rotation.x * (Math.PI / 180.0);
+				var rotation = evaluator.getFloat(anim.rotation, time);
+				anim.obj2d.rotation = rotation * (Math.PI / 180.0);
 			}
 
 			if(anim.position != null) {
-				var pos = evaluator.getVector(anim.position, time);
-				anim.obj2d.x = anim.elt2d.x + pos.x;
-				anim.obj2d.y = anim.elt2d.y + pos.y;
+				evaluator.getVector(anim.position, time, tmpPt);
+				anim.obj2d.x = anim.elt2d.x + tmpPt.x;
+				anim.obj2d.y = anim.elt2d.y + tmpPt.y;
 			}
 
 			if(anim.visibility != null)
@@ -107,7 +108,7 @@ class FX2DAnimation extends h2d.Object {
 					default:
 						var drawable = Std.downcast(anim.obj2d, h2d.Drawable);
 						if (drawable != null)
-							drawable.color = evaluator.getVector(anim.color, time);
+							evaluator.getVector(anim.color, time, drawable.color);
 				}
 			}
 

--- a/hrt/prefab/fx/Value.hx
+++ b/hrt/prefab/fx/Value.hx
@@ -8,6 +8,7 @@ enum Value {
 	VCurveScale(c: Curve, scale: Float);
 	VRandom(idx: Int, scale: Value);
 	VRandomScale(idx: Int, scale: Float);
+	VAddRandCurve(cst: Float, ridx: Int, rscale: Float, c: Curve);
 	VAdd(a: Value, b: Value);
 	VMult(a: Value, b: Value);
 	VVector(x: Value, y: Value, z: Value, ?w: Value);

--- a/hrt/prefab/l2d/Particle2D.hx
+++ b/hrt/prefab/l2d/Particle2D.hx
@@ -27,7 +27,7 @@ class Particles extends h2d.Particles {
 		super(parent);
 		randomSeed = Std.random(0xFFFFFF);
 		random = new hxd.Rand(randomSeed);
-		evaluator = new Evaluator(random);
+		evaluator = new Evaluator();
 	}
 
 	function tick( dt : Float, full=true) {


### PR DESCRIPTION
This PR speeds-up particles update (`EmitterObject.setTime`) by a factor of 2. 
Data structures had to be completely refactored to avoid scattering data in tiny objects as much as possible.
Extra optimizations have been made on HL using @:struct for even more locality, but gains can be seen even on JS, due to having fewer objects overall in `ParticleInstance`. 
