### PR TITLE
Fix type collision of std.Type and TType

### DIFF
--- a/hide/comp/DomkitEditor.hx
+++ b/hide/comp/DomkitEditor.hx
@@ -63,12 +63,12 @@ class DomkitChecker extends ScriptEditor.ScriptChecker {
 		var dcfg : Array<String> = config.get("domkit-parsers");
 		if( dcfg != null ) {
 			for( name in dcfg ) {
-				var cl = Type.resolveClass(name);
+				var cl = std.Type.resolveClass(name);
 				if( cl == null ) {
 					ide.error("Couldn't find custom domkit parser "+name);
 					continue;
 				}
-				dcfg.push(Type.createInstance(cl,[]));
+				dcfg.push(std.Type.createInstance(cl,[]));
 			}
 		}
 		initComponents();
@@ -149,7 +149,7 @@ class DomkitChecker extends ScriptEditor.ScriptChecker {
 			domkitComp : domkit.Component.get(name, true),
 		};
 		if( c.domkitComp == null ) {
-			c.domkitComp = Type.createEmptyInstance(domkit.Component);
+			c.domkitComp = std.Type.createEmptyInstance(domkit.Component);
 			c.domkitComp.name = name;
 		}
 		components.set(name, c);


### PR DESCRIPTION
`Type` is defined at the beginning of the file with `import hscript.Checker.TType in Type;`. However, `std.Type` is used in some places but only `Type` is specified.

This bug is now detected with newer Haxe, and should be fixed.