### PR TITLE
Added fix for drag and drop onto cells

### DIFF
--- a/hide/comp/cdb/Cell.hx
+++ b/hide/comp/cdb/Cell.hx
@@ -32,6 +32,10 @@ class Cell {
 		this.column = column;
 		@:privateAccess line.cells.push(this);
 
+		// This gets used by drag and drop
+		var eroot = new Element(root);
+		eroot.prop("cellComp", this);
+
 		root.classList.add("t_" + typeNames[column.type.getIndex()]);
 		root.classList.add("n_" + column.name);
 

--- a/hide/comp/cdb/Cell.hx
+++ b/hide/comp/cdb/Cell.hx
@@ -33,8 +33,10 @@ class Cell {
 		@:privateAccess line.cells.push(this);
 
 		// This gets used by drag and drop
-		var eroot = new Element(root);
-		eroot.prop("cellComp", this);
+		if (column.type == TFile) {
+			var eroot = new Element(root);
+			eroot.prop("cellComp", this);
+		}
 
 		root.classList.add("t_" + typeNames[column.type.getIndex()]);
 		root.classList.add("n_" + column.name);


### PR DESCRIPTION
Drag and drop from the file browser doesn't work on the database cells.

This adds the missing property to the cells in order to make it work.