### PR TITLE
Remove all external calls to SceneEditor.sceneRefresh/refresh

### DIFF
--- a/hide/comp/SceneEditor.hx
+++ b/hide/comp/SceneEditor.hx
@@ -2676,12 +2676,6 @@ class SceneEditor {
 	}
 
 	public function onPrefabChange(p: PrefabElement, ?pname: String) {
-		// TODO : implement
-		/*var model = p.to(hrt.prefab.Model);
-		if(model != null && pname == "source") {
-			refreshScene();
-			return;
-		}*/
 
 		if(p != sceneData) {
 			var el = tree.getElement(p);
@@ -3686,11 +3680,13 @@ class SceneEditor {
 	public function setEditorOnly(elements : Array<PrefabElement>, enable: Bool) {
 		var old = [for(e in elements) e.editorOnly];
 		function apply(on) {
+			beginRebuild();
 			for(i in 0...elements.length) {
 				elements[i].editorOnly = on ? enable : old[i];
 				onPrefabChange(elements[i]);
+				queueRebuild(elements[i]);
 			}
-			refreshScene();
+			endRebuild();
 		}
 		apply(true);
 		undo.change(Custom(function(undo) {
@@ -3704,11 +3700,13 @@ class SceneEditor {
 	public function setInGameOnly(elements : Array<PrefabElement>, enable: Bool) {
 		var old = [for(e in elements) e.inGameOnly];
 		function apply(on) {
+			beginRebuild();
 			for(i in 0...elements.length) {
 				elements[i].inGameOnly = on ? enable : old[i];
 				onPrefabChange(elements[i]);
+				queueRebuild(elements[i]);
 			}
-			refreshScene();
+			endRebuild();
 		}
 		apply(true);
 		undo.change(Custom(function(undo) {
@@ -3777,7 +3775,6 @@ class SceneEditor {
 					elements[i].locked = redo ? locked : prev[i];
 			}), function() {
 				tree.refresh();
-				refreshScene();
 			});
 		}
 
@@ -4148,7 +4145,7 @@ class SceneEditor {
 
 		prefab.editorRemoveInstance();
 
-		if (prefab.enabled) {
+		if (prefab.enabled && !prefab.inGameOnly) {
 			prefab.shared.current3d = prefab.parent?.findFirstLocal3d() ?? root3d;
 			prefab.shared.current2d = prefab.parent?.findFirstLocal2d() ?? root2d;
 			prefab.setEditor(this, this.scene);

--- a/hide/comp/SceneEditor.hx
+++ b/hide/comp/SceneEditor.hx
@@ -3898,12 +3898,6 @@ class SceneEditor {
 	}
 
 	public function deleteElements(elts : Array<PrefabElement>, ?then: Void->Void, doRefresh : Bool = true, enableUndo : Bool = true) {
-		// for (e in elts) {
-		// 	removeInstance(e);
-		// 	e.parent = null;
-		// }
-
-		var fullRefresh = false;
 		var undoes = [];
 		beginRebuild();
 		for(elt in elts) {

--- a/hide/comp/SceneEditor.hx
+++ b/hide/comp/SceneEditor.hx
@@ -3820,16 +3820,16 @@ class SceneEditor {
 		var newElements = [];
 		var lastElem = elements[elements.length-1];
 		var lastIndex = lastElem.parent.children.indexOf(lastElem);
+		beginRebuild();
 		for(i => elt in elements) {
 			@:pirvateAccess var clone = hrt.prefab.Prefab.createFromDynamic(haxe.Json.parse(haxe.Json.stringify(elt.serialize())), null, elt.parent.shared);
 			var index = lastIndex+1+i;
 			elt.parent.children.insert(index, clone);
 			@:bypassAccessor clone.parent = elt.parent;
-			clone.shared.current2d = elt.parent.findFirstLocal2d();
-			clone.shared.current3d = elt.parent.findFirstLocal3d();
-			clone.make();
-
 			autoName(clone);
+
+			queueRebuild(clone);
+
 			newElements.push(clone);
 
 			var all = clone.flatten();
@@ -3842,6 +3842,7 @@ class SceneEditor {
 				else elt.parent.children.insert(index, clone);
 			});
 		}
+		endRebuild();
 
 		refreshTree(function() {
 			selectElements(newElements, NoHistory);

--- a/hide/comp/SceneEditor.hx
+++ b/hide/comp/SceneEditor.hx
@@ -3666,11 +3666,13 @@ class SceneEditor {
 	public function setEnabled(elements : Array<PrefabElement>, enable: Bool) {
 		var old = [for(e in elements) e.enabled];
 		function apply(on) {
+			beginRebuild();
 			for(i in 0...elements.length) {
 				elements[i].enabled = on ? enable : old[i];
 				onPrefabChange(elements[i]);
+				queueRebuild(elements[i]);
 			}
-			refreshScene();
+			endRebuild();
 		}
 		apply(true);
 		undo.change(Custom(function(undo) {
@@ -4146,10 +4148,12 @@ class SceneEditor {
 
 		prefab.editorRemoveInstance();
 
-		prefab.shared.current3d = prefab.parent?.findFirstLocal3d() ?? root3d;
-		prefab.shared.current2d = prefab.parent?.findFirstLocal2d() ?? root2d;
-		prefab.setEditor(this, this.scene);
-		prefab.make();
+		if (prefab.enabled) {
+			prefab.shared.current3d = prefab.parent?.findFirstLocal3d() ?? root3d;
+			prefab.shared.current2d = prefab.parent?.findFirstLocal2d() ?? root2d;
+			prefab.setEditor(this, this.scene);
+			prefab.make();
+		}
 
 		for( p in prefab.flatten() ) {
 			makeInteractive(p);

--- a/hide/prefab/HideProps.hx
+++ b/hide/prefab/HideProps.hx
@@ -8,7 +8,6 @@ typedef HideProps = {
 	@:optional dynamic function allowChildren( cl : Class<hrt.prefab.Prefab> ) : Bool;
 	@:optional dynamic function allowParent( p : hrt.prefab.Prefab ) : Bool;
 	@:optional dynamic function onChildUpdate( p : hrt.prefab.Prefab ) : Void;
-	@:optional dynamic function onChildListChanged() : Void;
 	@:optional dynamic function onResourceRenamed( map : (oldPath : String) -> String ) : Void;
 	@:optional dynamic function hideChildren( p : hrt.prefab.Prefab ) : Bool;
 }

--- a/hide/prefab/PolygonEditor.hx
+++ b/hide/prefab/PolygonEditor.hx
@@ -720,12 +720,12 @@ class PolygonEditor {
 
 				refreshPolygon();
 				refreshInteractive();
-				ctx.scene.editor.refresh();
+				ctx.scene.editor.queueRebuild(polygonPrefab);
 			}));
 
 			refreshPolygon();
 			refreshInteractive();
-			ctx.scene.editor.refresh();
+			ctx.scene.editor.queueRebuild(polygonPrefab);
 		});
 
 		props.find(".snap").click(function(_) {
@@ -775,7 +775,7 @@ class PolygonEditor {
 
 			refreshPolygon();
 			refreshInteractive();
-			ctx.scene.editor.refresh();
+			ctx.scene.editor.queueRebuild(polygonPrefab);
 
 			undo.change(Custom(function(undo) {
 				var undoDelta = deltaChildSpace.clone();
@@ -826,7 +826,8 @@ class PolygonEditor {
 
 				refreshPolygon();
 				refreshInteractive();
-				ctx.scene.editor.refresh();
+							ctx.scene.editor.queueRebuild(polygonPrefab);
+
 			}));
 		});
 

--- a/hide/prefab/SplineEditor.hx
+++ b/hide/prefab/SplineEditor.hx
@@ -422,7 +422,7 @@ class SplineEditor {
 							obj3d.applyTransform();
 							prefab.updateInstance();
 							showViewers();
-							@:privateAccess editContext.scene.editor.refresh(Partial);
+							@:privateAccess editContext.scene.editor.refreshTree();
 							showViewers();
 							createGizmos();
 						}
@@ -481,7 +481,7 @@ class SplineEditor {
 								editContext.scene.editor.deleteElements([sp], () -> {}, false, false);
 								for (sp in prefab.points)
 									sp.computeName();
-								@:privateAccess editContext.scene.editor.refresh(Partial);
+								@:privateAccess editContext.scene.editor.refreshTree();
 								prefab.updateInstance();
 								showViewers();
 								createGizmos();
@@ -502,7 +502,7 @@ class SplineEditor {
 						editContext.scene.editor.deleteElements([sp], () -> {}, false, false);
 						for (sp in prefab.points)
 							sp.computeName();
-						@:privateAccess editContext.scene.editor.refresh(Partial);
+						@:privateAccess editContext.scene.editor.refreshTree();
 
 						prefab.updateInstance();
 						showViewers();
@@ -520,7 +520,7 @@ class SplineEditor {
 								editContext.scene.editor.deleteElements([sp], () -> {}, false, false);
 								for (sp in prefab.points)
 									sp.computeName();
-								@:privateAccess editContext.scene.editor.refresh(Partial);
+								@:privateAccess editContext.scene.editor.refreshTree();
 								prefab.updateInstance();
 								showViewers();
 								createGizmos();
@@ -613,7 +613,7 @@ class SplineEditor {
 				sp.rotationZ += hxd.Math.degToRad(180);
 				sp.computeName();
 			}
-			@:privateAccess editContext.scene.editor.refresh(Partial);
+			@:privateAccess editContext.scene.editor.refreshTree();
 
 			undo.change(Custom(function(undo) {
 				prefab.children.reverse();
@@ -621,7 +621,7 @@ class SplineEditor {
 					sp.rotationZ += hxd.Math.degToRad(180);
 					sp.computeName();
 				}
-				@:privateAccess editContext.scene.editor.refresh(Partial);
+				@:privateAccess editContext.scene.editor.refreshTree();
 			}));
 			ctx.onChange(prefab, null);
 			removeGizmos();

--- a/hide/view/FXEditor.hx
+++ b/hide/view/FXEditor.hx
@@ -158,15 +158,6 @@ private class FXSceneEditor extends hide.comp.SceneEditor {
 		parent.onSelect(elts);
 	}
 
-	override function refresh(?mode: hide.comp.SceneEditor.RefreshMode, ?callb:Void->Void) {
-		// Always refresh scene
-		refreshScene();
-		refreshTree(callb);
-		parent.onRefreshScene();
-	}
-
-
-
 	override function applyTreeStyle(p: PrefabElement, el: Element, ?pname: String, ?tree: hide.comp.IconTree<PrefabElement>) {
 		super.applyTreeStyle(p, el, pname, tree);
 		if (el == null)

--- a/hide/view/FXEditor.hx
+++ b/hide/view/FXEditor.hx
@@ -746,12 +746,12 @@ class FXEditor extends hide.view.FileView {
 				}
 			}
 
-			sceneEditor.refresh();
+			sceneEditor.queueRebuild(@:privateAccess sceneEditor.sceneData);
 			rebuildAnimPanel();
 		}
 
 		if (pname == "blendParam") {
-			sceneEditor.refresh();
+			sceneEditor.queueRebuild(@:privateAccess sceneEditor.sceneData);
 			rebuildAnimPanel();
 		}
 
@@ -1379,11 +1379,10 @@ class FXEditor extends hide.view.FileView {
 				else
 					element.children.push(c);
 			}
-			sceneEditor.refresh();
+			sceneEditor.queueRebuild(@:privateAccess sceneEditor.sceneData);
 		}));
-		sceneEditor.refresh(function() {
-			sceneEditor.selectElements([element]);
-		});
+		sceneEditor.queueRebuild(@:privateAccess sceneEditor.sceneData);
+		sceneEditor.selectElements([element]);
 		return added;
 	}
 

--- a/hide/view/FXEditor.hx
+++ b/hide/view/FXEditor.hx
@@ -32,10 +32,6 @@ class FXEditContext extends hide.prefab.EditContext {
 		super.onChange(p, propName);
 		parent.onPrefabChange(p, propName);
 	}
-
-	override function rebuildPrefab(p : hrt.prefab.Prefab, ?sceneOnly) {
-		parent.sceneEditor.refreshScene();
-	}
 }
 
 @:access(hide.view.FXEditor)
@@ -770,13 +766,6 @@ class FXEditor extends hide.view.FileView {
 				this.curveEditor.refreshGraph();
 			}
 		}
-
-	}
-
-	function onRefreshScene() {
-		var renderProps = cast(data, hrt.prefab.Prefab).find(hrt.prefab.RenderProps);
-		if(renderProps != null)
-			renderProps.applyProps(scene.s3d.renderer);
 	}
 
 	override function onDragDrop(items : Array<String>, isDrop : Bool) {
@@ -1722,8 +1711,6 @@ class FXEditor extends hide.view.FileView {
 			if(currentTime >= previewMax) {
 				currentTime = previewMin;
 
-				//if(data.scriptCode != null && data.scriptCode.length > 0)
-					//sceneEditor.refreshScene(); // This allow to reset the scene when values are modified causes edition issues, solves
 				for(f in allFx)
 					f.setRandSeed(Std.random(0xFFFFFF));
 			}

--- a/hide/view/Prefab.hx
+++ b/hide/view/Prefab.hx
@@ -57,11 +57,6 @@ class PrefabSceneEditor extends hide.comp.SceneEditor {
 		this.localTransform = false; // TODO: Expose option
 	}
 
-	override function refresh(?mode, ?callback) {
-		parent.onRefresh();
-		super.refresh(mode, callback);
-	}
-
 	override function update(dt) {
 		super.update(dt);
 		parent.onUpdate(dt);

--- a/hrt/prefab/Light.hx
+++ b/hrt/prefab/Light.hx
@@ -468,11 +468,11 @@ class Light extends Object3D {
 		return true;
 	}
 
-	override function editorRemoveInstance() : Bool {
+	override function editorRemoveInstance() : Void {
 		if (icon != null) {
 			icon.remove();
 		}
-		return super.editorRemoveInstance();
+		super.editorRemoveInstance();
 	}
 
 	override function edit( ctx : hide.prefab.EditContext ) {

--- a/hrt/prefab/Material.hx
+++ b/hrt/prefab/Material.hx
@@ -249,14 +249,15 @@ class Material extends Prefab {
 	}
 
 	#if editor
-	override function editorRemoveInstance() : Bool {
+	override function editorRemoveInstance() : Void {
 		if (previewSphere != null) {
 			previewSphere.remove();
-			return true;
 		}
-		// temporary untill we find a proper way to remove a material
-		shared.editor.queueRebuild(parent);
-		return false;
+		else {
+			// temporary untill we find a proper way to remove a material
+			shared.editor.queueRebuild(parent);
+		}
+		super.editorRemoveInstance();
 	}
 
 	override function makeInteractive() : hxd.SceneEvents.Interactive {

--- a/hrt/prefab/Material.hx
+++ b/hrt/prefab/Material.hx
@@ -254,6 +254,8 @@ class Material extends Prefab {
 			previewSphere.remove();
 			return true;
 		}
+		// temporary untill we find a proper way to remove a material
+		shared.editor.queueRebuild(parent);
 		return false;
 	}
 
@@ -604,11 +606,11 @@ class Material extends Prefab {
 				materialName = undo ? previous : actual;
 				ctx.onChange(this, null);
 				ctx.rebuildProperties();
-				ctx.scene.editor.refresh();
+				ctx.scene.editor.queueRebuild(this);
 			}));
 			ctx.onChange(this, null);
 			ctx.rebuildProperties();
-			ctx.scene.editor.refresh();
+			ctx.scene.editor.queueRebuild(this);
 
 			var fx = findParent(hrt.prefab.fx.FX);
 			if(fx != null)

--- a/hrt/prefab/Model.hx
+++ b/hrt/prefab/Model.hx
@@ -141,7 +141,7 @@ class Model extends Object3D {
 			if( pname == "retargetIgnore" && ctx.properties.isTempChange ) return;
 
 			if (pname == "source")
-				ctx.scene.editor.refreshScene();
+				ctx.scene.editor.queueRebuild(this);
 
 			ctx.onChange(this, pname);
 		});

--- a/hrt/prefab/Object2D.hx
+++ b/hrt/prefab/Object2D.hx
@@ -119,11 +119,11 @@ class Object2D extends Prefab {
 		};
 	}
 
-	override function editorRemoveInstance() : Bool {
+	override function editorRemoveInstance() : Void {
 		if (local2d != null) {
 			local2d.remove();
 		}
-		return true;
+		super.editorRemoveInstance();
 	}
 
 	override function edit( ctx : hide.prefab.EditContext ) {

--- a/hrt/prefab/Object3D.hx
+++ b/hrt/prefab/Object3D.hx
@@ -449,12 +449,12 @@ class Object3D extends Prefab {
 		return int;
 	}
 
-	override function editorRemoveInstance() : Bool {
+	override function editorRemoveInstance() : Void {
 		if (local3d != null)
 			local3d.remove();
 		if (editorIcon != null)
 			editorIcon.remove();
-		return true;
+		super.editorRemoveInstance();
 	}
 
 	override function edit( ctx : hide.prefab.EditContext ) {

--- a/hrt/prefab/Prefab.hx
+++ b/hrt/prefab/Prefab.hx
@@ -584,11 +584,8 @@ class Prefab {
 
 	/**
 		Called by the editor to remove the objects created by this prefab but not it's children.
-		Returns true if all the objects were succesfully removed, false otherwise (this will cause
-			a full rebuild of the scene )
 	**/
-	public function editorRemoveInstance() : Bool {
-		return false;
+	public function editorRemoveInstance() : Void {
 	}
 
 	/**

--- a/hrt/prefab/Prefab.hx
+++ b/hrt/prefab/Prefab.hx
@@ -584,6 +584,14 @@ class Prefab {
 	}
 
 	/**
+		Called by the editor when a child of this object gets build or rebuilded.
+		If this function returns true, this prefab will get rebuild as well.
+	**/
+	public function onEditorChildRebuild(child: Prefab) : Bool {
+		return false;
+	}
+
+	/**
 		Called when the hide editor wants to edit this Prefab.
 		Used to create the various editor interfaces
 	**/

--- a/hrt/prefab/Prefab.hx
+++ b/hrt/prefab/Prefab.hx
@@ -35,6 +35,14 @@ abstract ContextMake(ContextShared) from ContextShared to ContextShared {
 	}
 }
 
+#if editor
+enum TreeChangedResult {
+	Skip; /**Don't rebuild this prefab**/
+	Rebuild; /** Force rebuild this prefab **/
+	Notify(callback: Void -> Void); /**Call the callback once all the prefab that wanted rebuild have been rebuild. Call order betwteen multiple Notify are not guaranteed. Only one callback will be called by prefab in the tree**/
+}
+#end
+
 @:allow(hide)
 @:keepSub
 @:autoBuild(hrt.prefab.Macros.buildPrefab())
@@ -584,11 +592,10 @@ class Prefab {
 	}
 
 	/**
-		Called by the editor when a child of this object gets build or rebuilded.
-		If this function returns true, this prefab will get rebuild as well.
+		Called by the editor when a child of this object gets added, rebuild or removed.
 	**/
-	public function onEditorChildRebuild(child: Prefab) : Bool {
-		return false;
+	public function onEditorTreeChanged(child: Prefab) : TreeChangedResult {
+		return Skip;
 	}
 
 	/**

--- a/hrt/prefab/Shader.hx
+++ b/hrt/prefab/Shader.hx
@@ -158,9 +158,9 @@ class Shader extends Prefab {
 
 	#if editor
 
-	override function editorRemoveInstance() : Bool {
+	override function editorRemoveInstance() : Void {
 		shared.editor.queueRebuild(parent);
-		return true;
+		super.editorRemoveInstance();
 	}
 
 	function getEditProps(shaderDef: hxsl.SharedShader) : Array<hrt.prefab.Props.PropDef> {

--- a/hrt/prefab/Shader.hx
+++ b/hrt/prefab/Shader.hx
@@ -158,6 +158,11 @@ class Shader extends Prefab {
 
 	#if editor
 
+	override function editorRemoveInstance() : Bool {
+		shared.editor.queueRebuild(parent);
+		return true;
+	}
+
 	function getEditProps(shaderDef: hxsl.SharedShader) : Array<hrt.prefab.Props.PropDef> {
 		var props = [];
 		for(v in shaderDef.data.vars) {

--- a/hrt/prefab/fx/Emitter.hx
+++ b/hrt/prefab/fx/Emitter.hx
@@ -1768,8 +1768,8 @@ class Emitter extends Object3D {
 		return false; // Emitter removal is buggy
 	}*/
 
-	override function onEditorChildRebuild(child: Prefab) {
-		return true;
+	override function onEditorTreeChanged(child: Prefab) : hrt.prefab.Prefab.TreeChangedResult {
+		return Rebuild;
 	}
 
 	override function edit( ctx : hide.prefab.EditContext ) {

--- a/hrt/prefab/fx/Emitter.hx
+++ b/hrt/prefab/fx/Emitter.hx
@@ -1764,8 +1764,12 @@ class Emitter extends Object3D {
 	}
 
 	#if editor
-	override function editorRemoveInstance() : Bool {
+	/*override function editorRemoveInstance() : Bool {
 		return false; // Emitter removal is buggy
+	}*/
+
+	override function onEditorChildRebuild(child: Prefab) {
+		return true;
 	}
 
 	override function edit( ctx : hide.prefab.EditContext ) {

--- a/hrt/prefab/fx/FX.hx
+++ b/hrt/prefab/fx/FX.hx
@@ -581,11 +581,8 @@ class FX extends Object3D implements BaseFX {
 
 	#if editor
 
-	override function onEditorChildRebuild(prefab: Prefab) {
-		if (Std.is(prefab, Emitter)) {
-			return true;
-		}
-		return false;
+	override function onEditorTreeChanged(child: Prefab) : hrt.prefab.Prefab.TreeChangedResult {
+		return Rebuild;
 	}
 
 	public function refreshObjectAnims() : Void {

--- a/hrt/prefab/fx/FX.hx
+++ b/hrt/prefab/fx/FX.hx
@@ -581,6 +581,13 @@ class FX extends Object3D implements BaseFX {
 
 	#if editor
 
+	override function onEditorChildRebuild(prefab: Prefab) {
+		if (Std.is(prefab, Emitter)) {
+			return true;
+		}
+		return false;
+	}
+
 	public function refreshObjectAnims() : Void {
 		var fxanim = Std.downcast(local3d, FXAnimation);
 		fxanim.objAnims = null;

--- a/hrt/prefab/l3d/Instance.hx
+++ b/hrt/prefab/l3d/Instance.hx
@@ -148,13 +148,11 @@ class Instance extends Object3D {
 		return path;
 	}
 
-	override function editorRemoveInstance() : Bool {
-		if (!super.editorRemoveInstance())
-			return false;
+	override function editorRemoveInstance() : Void {
 		if (icon != null) {
 			icon.remove();
 		}
-		return true;
+		super.editorRemoveInstance();
 	}
 
 	override function getHideProps() : hide.prefab.HideProps {

--- a/hrt/prefab/l3d/MeshSpray.hx
+++ b/hrt/prefab/l3d/MeshSpray.hx
@@ -676,7 +676,7 @@ class MeshSpray extends Spray {
 						}
 						elt.val(newPath);
 						elt.html(extractItemName(newPath));
-						sceneEditor.refresh();
+						sceneEditor.queueRebuild(this);
 						undo.change(Custom(function(undo) {
 							if(undo) {
 								removeSourcePath(newPath);
@@ -689,7 +689,7 @@ class MeshSpray extends Spray {
 								}
 								elt.val(path);
 								elt.html(extractItemName(path));
-								sceneEditor.refresh();
+								sceneEditor.queueRebuild(this);
 							}
 							else {
 								removeSourcePath(elt.val());
@@ -702,7 +702,7 @@ class MeshSpray extends Spray {
 								}
 								elt.val(newPath);
 								elt.html(extractItemName(newPath));
-								sceneEditor.refresh();
+								sceneEditor.queueRebuild(this);
 							}
 						}));
 					}) },

--- a/hrt/prefab/l3d/PrefabSpray.hx
+++ b/hrt/prefab/l3d/PrefabSpray.hx
@@ -76,7 +76,7 @@ class PrefabSpray extends Spray {
 						}
 						elt.val(newPath);
 						elt.html(extractItemName(newPath));
-						sceneEditor.refresh();
+						sceneEditor.queueRebuild(this);
 						undo.change(Custom(function(undo) {
 							if(undo) {
 								removeSourcePath(newPath);
@@ -89,7 +89,7 @@ class PrefabSpray extends Spray {
 								}
 								elt.val(path);
 								elt.html(extractItemName(path));
-								sceneEditor.refresh();
+								sceneEditor.queueRebuild(this);
 							}
 							else {
 								removeSourcePath(elt.val());
@@ -102,7 +102,7 @@ class PrefabSpray extends Spray {
 								}
 								elt.val(newPath);
 								elt.html(extractItemName(newPath));
-								sceneEditor.refresh();
+								sceneEditor.queueRebuild(this);
 							}
 						}));
 					}) },

--- a/hrt/prefab/l3d/Spline.hx
+++ b/hrt/prefab/l3d/Spline.hx
@@ -151,11 +151,9 @@ class SplinePoint extends Object3D {
 
 	#if editor
 
-	override function editorRemoveInstance() : Bool {
-		haxe.Timer.delay(() -> { // wait for next frame, need the point to be removed from children to recompute spline accurately
-			@:privateAccess spline.computeSpline();
-		}, 0);
-		return super.editorRemoveInstance();
+	override function editorRemoveInstance() : Void {
+		shared.editor.queueRebuildCallback(() -> @:privateAccess spline.computeSpline());
+		super.editorRemoveInstance();
 	}
 
 	public function computeName() {

--- a/hrt/prefab/l3d/Spray.hx
+++ b/hrt/prefab/l3d/Spray.hx
@@ -569,6 +569,21 @@ class Spray extends Object3D {
 		}
 	}
 
+	override function editorRemoveInstance() : Void {
+		removeInteractiveBrush();
+		super.editorRemoveInstance();
+	}
+
+	override function makeObject(parent3d: h3d.scene.Object ) : h3d.scene.Object {
+		return new SprayObject(this, parent3d);
+	}
+
+	override function applyTransform() {
+		super.applyTransform();
+		cast(local3d, SprayObject).redraw();
+	}
+
+
 	static public function makePrimCircle(segments: Int, inner : Float = 0, rings : Int = 0) {
 		var points = [];
 		var uvs = [];

--- a/hrt/prefab/l3d/Spray.hx
+++ b/hrt/prefab/l3d/Spray.hx
@@ -338,8 +338,9 @@ class Spray extends Object3D {
 	function removeInteractiveBrush() {
 		if( interactive != null ) interactive.remove();
 		clearPreview();
-		if (wasEdited)
-			sceneEditor.refresh(Partial, () -> { });
+		if (wasEdited) {
+			//sceneEditor.queueRebuild(this);
+		}
 		wasEdited = false;
 		clearBrushes();
 	}

--- a/hrt/prefab/l3d/Spray.hx
+++ b/hrt/prefab/l3d/Spray.hx
@@ -126,6 +126,7 @@ class Spray extends Object3D {
 		cast(local3d, SprayObject).redraw();
 	}
 
+
 	override function editorRemoveInstance() : Void {
 		removeInteractiveBrush();
 	}

--- a/hrt/prefab/l3d/Spray.hx
+++ b/hrt/prefab/l3d/Spray.hx
@@ -126,9 +126,8 @@ class Spray extends Object3D {
 		cast(local3d, SprayObject).redraw();
 	}
 
-	override function editorRemoveInstance() : Bool {
+	override function editorRemoveInstance() : Void {
 		removeInteractiveBrush();
-		return super.editorRemoveInstance();
 	}
 
 	function clearPreview() {
@@ -568,21 +567,6 @@ class Spray extends Object3D {
 			g.z = originZ + 0.025;
 		}
 	}
-
-	override function editorRemoveInstance() : Void {
-		removeInteractiveBrush();
-		super.editorRemoveInstance();
-	}
-
-	override function makeObject(parent3d: h3d.scene.Object ) : h3d.scene.Object {
-		return new SprayObject(this, parent3d);
-	}
-
-	override function applyTransform() {
-		super.applyTransform();
-		cast(local3d, SprayObject).redraw();
-	}
-
 
 	static public function makePrimCircle(segments: Int, inner : Float = 0, rings : Int = 0) {
 		var points = [];

--- a/hrt/prefab/terrain/Terrain.hx
+++ b/hrt/prefab/terrain/Terrain.hx
@@ -603,7 +603,7 @@ class Terrain extends Object3D {
 			terrain.refreshAllGrids();
 			terrain.refreshAllTex();
 			if( editor != null ) {
-				editor.refresh();
+				shared.editor.queueRebuild(this);
 				@:privateAccess editor.blendEdges(terrain.tiles);
 			}
 			modified = true;


### PR DESCRIPTION
This vastly improves the workflow of the scene editor on complex scenes and/or with terrains that would loose all data when the scene was reloaded.