### PR TITLE
Fix installing to system directories on linux

### DIFF
--- a/hide/Config.hx
+++ b/hide/Config.hx
@@ -157,7 +157,7 @@ class Config {
 			Sys.exit(-1);
 		}
 
-		var userGlobals = loadConfig(new Config(defaults), hidePath + "/props.json");
+		var userGlobals = loadConfig(new Config(defaults), Ide.inst.userStatePath + "/props.json");
 
 		if( userGlobals.source.hide == null )
 			userGlobals.source.hide = {

--- a/hide/Config.hx
+++ b/hide/Config.hx
@@ -74,8 +74,13 @@ class Config {
 		var fullPath = ide.getPath(path);
 		if( Reflect.fields(source).length == 0 )
 			try sys.FileSystem.deleteFile(fullPath) catch( e : Dynamic ) {};
-		else
+		else {
+			var directory = haxe.io.Path.directory(fullPath);
+			if( !sys.FileSystem.exists(directory) ) {
+				sys.FileSystem.createDirectory(directory);
+			}
 			sys.io.File.saveContent(fullPath, ide.toJSON(source));
+		}
 	}
 
 	public function sync() {

--- a/hide/tools/IdeData.hx
+++ b/hide/tools/IdeData.hx
@@ -6,6 +6,7 @@ class IdeData {
 	public var projectDir(get,never) : String;
 	public var resourceDir(get,never) : String;
 	public var appPath(get, null): String;
+	public var userStatePath(get, null): String;
 	public var database : cdb.Database = new cdb.Database();
 	public var fileWatcher : hide.tools.FileWatcher;
 
@@ -109,6 +110,21 @@ class IdeData {
 			fatalError("Hide application path was not found");
 		}
 		return appPath = hidePath;
+	}
+
+	function get_userStatePath() {
+		var appPath = appPath;
+		if( sys.FileSystem.exists(appPath + "/props.json") ) {
+			return appPath;
+		}
+		if( Sys.systemName() ==  "Linux" ) {
+			var statePath = Sys.getEnv("XDG_STATE_HOME");
+			if( statePath == null ) {
+				statePath = Sys.getEnv("HOME") + "/.local/state";
+			}
+			return statePath + "/hide";
+		}
+		return appPath;
 	}
 
 	public function makeRelative( path : String ) {


### PR DESCRIPTION
On Linux, when you install to `/usr/` or `/usr/local/`, the app doesn't work because it doesn't have permissions to create a `props.json` file in those directories.

This fixes the issue by instead storing the user app state in the standard directory on Linux. If the props.json already exists in the app install directory, then it will continue to use that one so as to not affect existing installations.

For reference, here is the specification for storing program files on Linux: https://specifications.freedesktop.org/basedir-spec/latest/#variables.
> The $XDG_STATE_HOME contains state data that should persist between (application) restarts, but that is not important or portable enough to the user that it should be stored in $XDG_DATA_HOME. It may contain:
> - actions history (logs, history, recently used files, …)
> - current state of the application that can be reused on a restart (view, layout, open files, undo history, …)

Closes #102