### PR TITLE
ModelLibrary: use hash to determine isUpToDate

### DIFF
--- a/hrt/prefab/l3d/ModelLibrary.hx
+++ b/hrt/prefab/l3d/ModelLibrary.hx
@@ -126,6 +126,8 @@ class ModelLibrarySignature {
 			var lib = hxd.res.Loader.currentInstance.load(path).toModel().toHmd();
 			for( m in lib.header.materials ) {
 				var matsig = getMaterialSignature(lib, m);
+				if( matsig == null )
+					continue;
 				modelsig.materials.push(matsig);
 				for( matpath in [matsig.diffuseMapPath, matsig.normalMapPath, matsig.specularMapPath] ) {
 					if( matpath != null && !textureMap.exists(matpath) ) {

--- a/hrt/prefab/l3d/ModelLibrary.hx
+++ b/hrt/prefab/l3d/ModelLibrary.hx
@@ -458,7 +458,7 @@ class ModelLibrary extends Prefab {
 		}
 
 		var currentSig = if( paths != null )
-				ModelLibrarySignature.fromModels(filePath, paths)
+				ModelLibrarySignature.fromModels(source, paths)
 			else
 				ModelLibrarySignature.fromLib(this);
 		if( currentSig.computeHash() != sighash ) {


### PR DESCRIPTION
Instead of checking modification time of each models/textures, this PR compute a global hash `ModelLibrarySignature ` containing
- version of model library
- model (fbx) conversion rule
- hash of model/texture files
- model-texture relation

The order is preserved and duplicated elements are ignored.