### PR TITLE
Allow compilation on targets not supporting sys

### DIFF
--- a/hrt/prefab/ContextShared.hx
+++ b/hrt/prefab/ContextShared.hx
@@ -74,6 +74,7 @@ class ContextShared {
 	}
 
 	public function savePrefabDat(file : String, ext : String, prefab : String, bytes : haxe.io.Bytes ) {
+#if sys
 		var datDir = getFolderDatPath();
 		var instanceDir = datDir + "/" + prefab;
 
@@ -105,6 +106,9 @@ class ContextShared {
 		}else{
 			sys.io.File.saveBytes(file, bytes);
 		}
+#else
+		throw "Not implemented for this platform";
+#end
 	}
 
 	public function loadShader( path : String ) : Cache.ShaderDef {


### PR DESCRIPTION
I'm using heaps + hide with the js target on my macbook M1, but the project wouldn't compile because `sys.FileSystem` is not available on the target.

Since I'm only using it to load prefabs, I don't ever call the `savePrefabDat` method. Having it throw an exception seems like a good idea, since the rest of the hide library is usable on the js target, and I'm assuming the method is only used to serialize the data on the editor.

I used the same exception message as used in other places within the sys package.