### PR TITLE
Support `Command` / metaKey / macOS "command" key for keyboard shortcuts

### DIFF
--- a/hide/ui/Keys.hx
+++ b/hide/ui/Keys.hx
@@ -53,6 +53,8 @@ class Keys {
 			parts.push("Alt");
 		if( e.ctrlKey )
 			parts.push("Ctrl");
+		if( e.metaKey )
+			parts.push("Command");
 		if( e.shiftKey )
 			parts.push("Shift");
 		if( e.keyCode == hxd.Key.ALT || e.keyCode == hxd.Key.SHIFT || e.keyCode == hxd.Key.CTRL ) {


### PR DESCRIPTION
The `metaKey` [KeyboardEvent property](https://www.w3schools.com/jsref/event_key_metakey.asp) is the Windows key on Windows, and the `command` key on Mac

This is useful on MacOS, as `command` is often used as the `ctrl` equivalent for shortcuts (`command + s` -> save file, `command + z` -> undo)

In `defaultProps.json` changing `Ctrl` to `Command` ([from the NW.js shortcut docs](https://nwjs.readthedocs.io/en/latest/References/Shortcut/)) should allow usage of the MacOS `command` key now. Previously it did nothing. 