### PR TITLE
Add support for reference local overrides

### DIFF
--- a/bin/style.css
+++ b/bin/style.css
@@ -1128,11 +1128,6 @@ input[type=checkbox].indeterminate:after {
   word-break: break-word;
   margin-top: 4px;
 }
-.hide-properties dd span,
-.hide-properties dt span {
-  display: inline-block;
-  width: 20px;
-}
 .hide-properties dt {
   width: calc(80px - var(--level) * 2%);
   text-align: right;
@@ -1165,6 +1160,9 @@ input[type=checkbox].indeterminate:after {
 }
 .hide-properties input[type=checkbox] {
   width: 13px;
+}
+.hide-properties .warning {
+  color: red;
 }
 .hide-properties dt input[type=button] {
   width: 100%;
@@ -2732,6 +2730,9 @@ body.hide-subview .lm_controls {
 }
 .jstree .inRef {
   background: #444444 !important;
+}
+.jstree .isOverride {
+  background: #25346d !important;
 }
 .jstree a.locked {
   color: #666 !important;

--- a/bin/style.css
+++ b/bin/style.css
@@ -2734,6 +2734,14 @@ body.hide-subview .lm_controls {
 .jstree .isOverride {
   background: #25346d !important;
 }
+.jstree .isOverride.isOverriden > i,
+.jstree .isOverride.isOverriden > a {
+  color: cyan !important;
+}
+.jstree .isOverride.isOverriden.isOverridenNew i,
+.jstree .isOverride.isOverriden.isOverridenNew a {
+  color: #26c726 !important;
+}
 .jstree a.locked {
   color: #666 !important;
   font-style: italic;

--- a/bin/style.less
+++ b/bin/style.less
@@ -3168,6 +3168,18 @@ body.hide-subview {
 		background: #25346d !important;
 	}
 
+	.isOverride.isOverriden {
+		> i, > a {
+			color: cyan !important;
+		}
+	}
+
+	.isOverride.isOverriden.isOverridenNew {
+		i, a {
+			color: rgb(38, 199, 38) !important;
+		}
+	}
+
 	a.locked {
 		color: #666 !important;
 		font-style: italic;

--- a/bin/style.less
+++ b/bin/style.less
@@ -1231,11 +1231,6 @@ input[type=checkbox] {
 		text-wrap: wrap;
 		word-break: break-word;
 		margin-top:4px;
-
-		span {
-			display: inline-block;
-			width: 20px;
-		}
 	}
 
 	dt {
@@ -1276,6 +1271,10 @@ input[type=checkbox] {
 
 	input[type=checkbox] {
 		width:13px;
+	}
+
+	.warning {
+		color: red;
 	}
 
 	dt {
@@ -3163,6 +3162,10 @@ body.hide-subview {
 
 	.inRef {
 		background: rgb(68, 68, 68) !important;
+	}
+
+	.isOverride {
+		background: #25346d !important;
 	}
 
 	a.locked {

--- a/hide/comp/SceneEditor.hx
+++ b/hide/comp/SceneEditor.hx
@@ -3206,8 +3206,23 @@ class SceneEditor {
 		var obj3d  = p.to(Object3D);
 		el.toggleClass("disabled", !p.enabled);
 		var aEl = el.find("a").first();
-		var root = p.getRoot();
-		el.toggleClass("inRef", root != sceneData);
+
+		// reference
+		var isOverride = false;
+		var inRef = false;
+		if (p.shared.parentPrefab != null) {
+			var parentRef = Std.downcast(p.shared.parentPrefab, Reference);
+			if (parentRef != null) {
+				if (parentRef.editMode == Override) {
+					isOverride = true;
+				} else {
+					inRef = true;
+				}
+			}
+		}
+
+		el.toggleClass("inRef", inRef);
+		el.toggleClass("isOverride", isOverride);
 
 		var tag = getTag(p);
 

--- a/hide/comp/SceneEditor.hx
+++ b/hide/comp/SceneEditor.hx
@@ -2172,11 +2172,13 @@ class SceneEditor {
 	}
 
 	var treeRefreshing = false;
-	var queueRefresh = false;
+	var queueRefresh : Array<() -> Void> = null;
 
 	function refreshTree( ?callb ) {
 		if (treeRefreshing) {
-			queueRefresh = true;
+			queueRefresh ??= [];
+			if (callb != null)
+				queueRefresh.push(callb);
 			return;
 		}
 		treeRefreshing = true;
@@ -2193,9 +2195,10 @@ class SceneEditor {
 			if(callb != null) callb();
 
 			treeRefreshing = false;
-			if (queueRefresh) {
-				queueRefresh = false;
-				refreshTree();
+			if (queueRefresh != null) {
+				var list = queueRefresh;
+				queueRefresh = null;
+				refreshTree(() -> for (cb in list) cb());
 			}
 		});
 
@@ -3178,18 +3181,18 @@ class SceneEditor {
 			var path = modifiedRef.source;
 
 			var others = sceneData.findAll(Reference, (r) -> r.source == path && r != modifiedRef, true);
-			@:privateAccess
-			if (others.length > 0) {
-				var data = modifiedRef.refInstance.serialize();
-				beginRebuild();
-				for (ref in others) {
-					removeInstance(ref.refInstance, false);
-					@:privateAccess ref.setRef(data);
-					queueRebuild(ref);
-				}
-				endRebuild();
-				refreshTree();
-			}
+			// @:privateAccess
+			// if (others.length > 0) {
+			// 	var data = modifiedRef.refInstance.serialize();
+			// 	beginRebuild();
+			// 	for (ref in others) {
+			// 		removeInstance(ref.refInstance, false);
+			// 		@:privateAccess ref.setRef(data);
+			// 		queueRebuild(ref);
+			// 	}
+			// 	endRebuild();
+			// 	refreshTree();
+			// }
 		}
 
 		applySceneStyle(p);

--- a/hide/comp/SceneEditor.hx
+++ b/hide/comp/SceneEditor.hx
@@ -238,10 +238,6 @@ class ViewportOverlaysPopup extends hide.comp.Popup {
 			var btn = addButton("Scene Info", "info-circle", "sceneInformationToggle", () -> editor.updateStatusTextVisibility()).appendTo(group);
 			addButton("Wireframe", "connectdevelop", "wireframeToggle", () -> editor.updateWireframe()).appendTo(group);
 			addButton("Disable Scene Render", "eye-slash", "tog-scene-render", () -> {}).appendTo(group);
-
-			//btn.contextmenu(() -> {
-			//
-			//})
 		}
 
 
@@ -2529,10 +2525,6 @@ class SceneEditor {
 			if( isLocked(elt) ) toggleInteractive(elt, false);
 		}
 		var ref = Std.downcast(elt,Reference);
-		// @:privateAccess if( ref != null && ref.editMode != None && ref.refInstance != null ) {
-		// 	for( p in ref.refInstance.flatten() )
-		// 		makeInteractive(p);
-		// }
 	}
 
 	function toggleInteractive( e : PrefabElement, visible : Bool ) {

--- a/hide/comp/SceneEditor.hx
+++ b/hide/comp/SceneEditor.hx
@@ -717,46 +717,46 @@ class ViewModePopup extends hide.comp.Popup {
 }
 
 class IconVisibilityPopup extends hide.comp.Popup {
-    var editor : SceneEditor;
+	 var editor : SceneEditor;
 
-    public function new(?parent : Element, editor: SceneEditor) {
-        super(parent);
-        this.editor = editor;
+	 public function new(?parent : Element, editor: SceneEditor) {
+		  super(parent);
+		  this.editor = editor;
 
-        element.append(new Element("<p>Icon Visibility</p>"));
-        element.addClass("settings-popup");
-        element.css("max-width", "300px");
+		  element.append(new Element("<p>Icon Visibility</p>"));
+		  element.addClass("settings-popup");
+		  element.css("max-width", "300px");
 
-        var form_div = new Element("<div>").addClass("form-grid").appendTo(element);
+		  var form_div = new Element("<div>").addClass("form-grid").appendTo(element);
 
-        var editMode : hrt.tools.Gizmo.EditMode = @:privateAccess editor.gizmo.editMode;
+		  var editMode : hrt.tools.Gizmo.EditMode = @:privateAccess editor.gizmo.editMode;
 
 		var ide = hide.Ide.inst;
-        for (k => v in ide.show3DIconsCategory) {
-            var input = new Element('<input type="checkbox" name="snap" id="$k" value="$k"/>');
-            if (v)
-                input.get(0).toggleAttribute("checked", true);
-            input.change((e) -> {
+		  for (k => v in ide.show3DIconsCategory) {
+				var input = new Element('<input type="checkbox" name="snap" id="$k" value="$k"/>');
+				if (v)
+					 input.get(0).toggleAttribute("checked", true);
+				input.change((e) -> {
 				var val = !ide.show3DIconsCategory.get(k);
 				ide.show3DIconsCategory.set(k, val);
 				js.Browser.window.localStorage.setItem(hrt.impl.EditorTools.iconVisibilityKey(k), val ? "true" : "false");
-            });
-            form_div.append(input);
-            form_div.append(new Element('<label for="$k" class="left">$k</label>'));
-        }
-    }
+				});
+				form_div.append(input);
+				form_div.append(new Element('<label for="$k" class="left">$k</label>'));
+		  }
+	 }
 }
 
 class HelpPopup extends hide.comp.Popup {
 	var editor : SceneEditor;
 
 	public function new(?parent : Element, editor: SceneEditor, ?shortcuts: Array<{name:String, shortcut:String}>) {
-        super(parent);
-        this.editor = editor;
+		  super(parent);
+		  this.editor = editor;
 
-        element.append(new Element("<p>Shortcuts</p>"));
-        element.addClass("settings-popup");
-        element.css("max-width", "300px");
+		  element.append(new Element("<p>Shortcuts</p>"));
+		  element.addClass("settings-popup");
+		  element.css("max-width", "300px");
 
 		var form_div = new Element("<div>").addClass("form-grid").appendTo(element);
 
@@ -916,9 +916,9 @@ class RenderPropsPopup extends Popup {
 @:access(hide.comp.SceneEditor)
 class CustomEditor {
 
-    var ide(get, never) : hide.Ide;
+	 var ide(get, never) : hide.Ide;
 	function get_ide() { return editor.ide; }
-    var editor : SceneEditor;
+	 var editor : SceneEditor;
 
 	var element : hide.Element;
 
@@ -926,9 +926,9 @@ class CustomEditor {
 		this.editor = editor;
 	}
 
-    public function setElementSelected( p : hrt.prefab.Prefab, b : Bool ) {
+	 public function setElementSelected( p : hrt.prefab.Prefab, b : Bool ) {
 		return true;
-    }
+	 }
 
 	public function update( dt : Float ) {
 
@@ -991,11 +991,11 @@ class SceneEditor {
 	public var curEdit(default, null) : SceneEditorContext;
 	public var snapToGround = false;
 
-    public var snapToggle = false;
-    public var snapMoveStep = 1.0;
-    public var snapRotateStep = 15.0;
-    public var snapScaleStep = 1.0;
-    public var snapForceOnGrid = false;
+	 public var snapToggle = false;
+	 public var snapMoveStep = 1.0;
+	 public var snapRotateStep = 15.0;
+	 public var snapScaleStep = 1.0;
+	 public var snapForceOnGrid = false;
 
 	public var localTransform = true;
 	public var selfOnlyTransform = false;
@@ -1082,11 +1082,17 @@ class SceneEditor {
 
 	public var lastFocusObjects : Array<Object> = [];
 
-	public function new(view, data) {
+
+	// Called when the sceneEditor scene has finished loading
+	// Use it to call setPrefab() to set the content of the scene
+	dynamic public function onSceneReady() {
+
+	}
+
+	public function new(view) {
 		ready = false;
 		ide = hide.Ide.inst;
 		this.view = view;
-		this.sceneData = data;
 
 		event = new hxd.WaitEvent();
 
@@ -1106,7 +1112,7 @@ class SceneEditor {
 		var sceneEl = new Element('<div class="heaps-scene"></div>');
 		scene = new hide.comp.Scene(view.config, null, sceneEl);
 		scene.editor = this;
-		scene.onReady = onSceneReady;
+		scene.onReady = onSceneReadyInternal;
 		scene.onResize = function() {
 			if( cameraController2D != null ) cameraController2D.toTarget();
 			onResize();
@@ -1307,23 +1313,23 @@ class SceneEditor {
 		grid.scale(1);
 		grid.material.mainPass.setPassName("overlay");
 
-        if (snapToggle) {
-    		gridStep = snapMoveStep;
-        }
-        else {
-            gridStep = ide.currentConfig.get("sceneeditor.gridStep");
-        }
+		  if (snapToggle) {
+	 		gridStep = snapMoveStep;
+		  }
+		  else {
+				gridStep = ide.currentConfig.get("sceneeditor.gridStep");
+		  }
 		gridSize = ide.currentConfig.get("sceneeditor.gridSize");
 
 		var col = h3d.Vector.fromColor(scene?.engine?.backgroundColor ?? 0);
 		var hsl = col.toColorHSL();
 
-        var mov = 0.1;
+		  var mov = 0.1;
 
-        if (snapToggle) {
-            mov = 0.2;
-            hsl.y += (1.0-hsl.y) * 0.2;
-        }
+		  if (snapToggle) {
+				mov = 0.2;
+				hsl.y += (1.0-hsl.y) * 0.2;
+		  }
 		if(hsl.z > 0.5) hsl.z -= mov;
 		else hsl.z += mov;
 
@@ -1348,12 +1354,12 @@ class SceneEditor {
 
 		var hsl = color.toColorHSL();
 
-        var mov = 0.1;
+		  var mov = 0.1;
 
-        if (snapToggle) {
-            mov = 0.2;
-            hsl.y += (1.0-hsl.y) * 0.2;
-        }
+		  if (snapToggle) {
+				mov = 0.2;
+				hsl.y += (1.0-hsl.y) * 0.2;
+		  }
 		if(hsl.z > 0.5) hsl.z -= mov;
 		else hsl.z += mov;
 
@@ -1428,16 +1434,16 @@ class SceneEditor {
 		haxe.Timer.delay(function() event.wait(0.5, updateStats), 0);
 	}
 
-    public function getSnapStatus() : Bool {
-        var ctrl = K.isDown(K.CTRL);
-        return (snapToggle && !ctrl) || (!snapToggle && ctrl);
-    };
+	 public function getSnapStatus() : Bool {
+		  var ctrl = K.isDown(K.CTRL);
+		  return (snapToggle && !ctrl) || (!snapToggle && ctrl);
+	 };
 
-    public function snap(value: Float, step:Float) : Float {
-        if (step > 0.0 && getSnapStatus())
-            value = hxd.Math.round(value / step) * step;
-        return value;
-    }
+	 public function snap(value: Float, step:Float) : Float {
+		  if (step > 0.0 && getSnapStatus())
+				value = hxd.Math.round(value / step) * step;
+		  return value;
+	 }
 
 	public function gizmoSnap(value: Float, mode: hrt.tools.Gizmo.EditMode) : Float {
 		switch(mode) {
@@ -1522,7 +1528,7 @@ class SceneEditor {
 		if (tree == null)
 			tree = this.tree;
 
-        focusObjects(getSelectedLocal3D());
+		  focusObjects(getSelectedLocal3D());
 		var selected3d = getSelectedLocal3D();
 		for(obj in selectedPrefabs)
 			tree.revealNode(obj);
@@ -1712,9 +1718,9 @@ class SceneEditor {
 			return;
 
 		var id = Std.parseInt(settings.camTypeIndex) ?? 0;
-        var newClass = CameraControllerEditor.controllersClasses[id];
-        if (Type.getClass(cameraController) != newClass.cl)
-            switchCamController(newClass.cl);
+		  var newClass = CameraControllerEditor.controllersClasses[id];
+		  if (Type.getClass(cameraController) != newClass.cl)
+				switchCamController(newClass.cl);
 
 		scene.s3d.camera.pos.set(settings.x, settings.y, settings.z);
 		scene.s3d.camera.target.set(settings.tx, settings.ty, settings.tz);
@@ -1769,53 +1775,45 @@ class SceneEditor {
 		}
 	}
 
-    function loadSnapSettings() {
-        function sanitize(value:Dynamic, def: Dynamic) {
-            if (value == null || value == 0.0)
-                return def;
-            return value;
-        }
-        @:privateAccess snapMoveStep = sanitize(view.getDisplayState("snapMoveStep"), snapMoveStep);
-        @:privateAccess snapRotateStep = sanitize(view.getDisplayState("snapRotateStep"), snapRotateStep);
-        @:privateAccess snapScaleStep = sanitize(view.getDisplayState("snapScaleStep"), snapScaleStep);
-        @:privateAccess snapForceOnGrid = view.getDisplayState("snapForceOnGrid");
-    }
+	function loadSnapSettings() {
+		function sanitize(value:Dynamic, def: Dynamic) {
+			if (value == null || value == 0.0)
+					return def;
+			return value;
+		}
+		@:privateAccess snapMoveStep = sanitize(view.getDisplayState("snapMoveStep"), snapMoveStep);
+		@:privateAccess snapRotateStep = sanitize(view.getDisplayState("snapRotateStep"), snapRotateStep);
+		@:privateAccess snapScaleStep = sanitize(view.getDisplayState("snapScaleStep"), snapScaleStep);
+		@:privateAccess snapForceOnGrid = view.getDisplayState("snapForceOnGrid");
+	}
 
-    public function saveSnapSettings() {
-        @:privateAccess view.saveDisplayState("snapMoveStep", snapMoveStep);
-        @:privateAccess view.saveDisplayState("snapRotateStep", snapRotateStep);
-        @:privateAccess view.saveDisplayState("snapScaleStep", snapScaleStep);
-        @:privateAccess view.saveDisplayState("snapForceOnGrid", snapForceOnGrid);
-    }
+	public function saveSnapSettings() {
+		@:privateAccess view.saveDisplayState("snapMoveStep", snapMoveStep);
+		@:privateAccess view.saveDisplayState("snapRotateStep", snapRotateStep);
+		@:privateAccess view.saveDisplayState("snapScaleStep", snapScaleStep);
+		@:privateAccess view.saveDisplayState("snapForceOnGrid", snapForceOnGrid);
+	}
 
-    function toggleSnap(?force: Bool) {
-        if (force != null)
-            snapToggle = force;
-        else
-            snapToggle = !snapToggle;
+	function toggleSnap(?force: Bool) {
+		if (force != null)
+			snapToggle = force;
+		else
+			snapToggle = !snapToggle;
 
-        var snap = new Element("#snap").get(0);
-        if (snap != null) {
-            snap.toggleAttribute("checked", snapToggle);
-        }
-
-        updateGrid();
-    }
-
-	function onSceneReady() {
-		// Load display state
-		{
-			var all = sceneData.flatten(PrefabElement, null);
-			var list = @:privateAccess view.getDisplayState("hideList");
-			if(list != null) {
-				var m = [for(i in (list:Array<Dynamic>)) i => true];
-				for(p in all) {
-					if(m.exists(p.getAbsPath(true, true)))
-						hideList.set(p, true);
-				}
-			}
+		var snap = new Element("#snap").get(0);
+		if (snap != null) {
+			snap.toggleAttribute("checked", snapToggle);
 		}
 
+		updateGrid();
+	}
+
+	public function setPrefab(prefab: hrt.prefab.Prefab) {
+		sceneData = prefab;
+		refreshScene();
+	}
+
+	function onSceneReadyInternal() {
 		tree.saveDisplayKey = view.saveDisplayKey + '/tree';
 		renderPropsTree.saveDisplayKey = view.saveDisplayKey + '/renderPropsTree';
 
@@ -1927,6 +1925,8 @@ class SceneEditor {
 		};
 
 		tree.get = function(o:PrefabElement) {
+			if (sceneData == null)
+				return [];
 			var objs = o == null ? sceneData.children : Lambda.array(o);
 			return getFunc(objs, o);
 		};
@@ -2137,17 +2137,21 @@ class SceneEditor {
 		tree.applyStyle = function(p, el) applyTreeStyle(p, el);
 		renderPropsTree.applyStyle = function(p, el) applyTreeStyle(p, el, renderPropsTree);
 
+		ready = true;
+
+		onSceneReady();
+
 		selectElements([]);
-		refreshScene();
 		this.camera2D = camera2D;
 
 		updateViewportOverlays();
 
-		ready = true;
+
 		for (callback in readyDelayed) {
 			callback();
 		}
 		readyDelayed.empty();
+
 	}
 
 	function checkAllowParent(prefabInf:hrt.prefab.Prefab.PrefabInfo, prefabParent : PrefabElement) : Bool {
@@ -2415,13 +2419,16 @@ class SceneEditor {
 	}
 
 	public function refreshScene() {
+
 		clearWatches();
 
 		if (root2d != null) root2d.remove();
 		if (root3d != null) root3d.remove();
 
-		if (sceneData != null)
-			sceneData.dispose();
+		if (sceneData == null)
+			return;
+
+		sceneData.dispose();
 
 		hrt.impl.Gradient.purgeEditorCache();
 
@@ -2466,6 +2473,19 @@ class SceneEditor {
 		scene.init();
 		scene.engine.backgroundColor = bgcol;
 
+		// Load display state
+		{
+			var all = sceneData.flatten(PrefabElement, null);
+			var list = @:privateAccess view.getDisplayState("hideList");
+			if(list != null) {
+				var m = [for(i in (list:Array<Dynamic>)) i => true];
+				for(p in all) {
+					if(m.exists(p.getAbsPath(true, true)))
+						hideList.set(p, true);
+				}
+			}
+		}
+
 		rebuild(sceneData);
 
 		var all = sceneData.all();
@@ -2477,6 +2497,8 @@ class SceneEditor {
 		setRenderProps();
 
 		onRefresh();
+
+
 	}
 
 	function getAllWithRefs<T:PrefabElement>( p : PrefabElement, cl : Class<T>, ?arr : Array<T>, forceLoad: Bool = false ) : Array<T> {
@@ -2747,7 +2769,7 @@ class SceneEditor {
 				if(rot != null) {
 					rot.toMatrix(transf);
 
-                }
+					 }
 				if(translate != null)
 					transf.translate(translate.x, translate.y, translate.z);
 				for(i in 0...sceneObjs.length) {
@@ -2781,21 +2803,21 @@ class SceneEditor {
 					var obj3d = objects3d[i];
 					var obj3dPrevTransform = obj3d.getTransform();
 					var euler = newMat.getEulerAngles();
-                    if (translate != null && translate.length() > 0.0001 && snapForceOnGrid) {
-                        obj3d.x = snap(quantize(newMat.tx, posQuant), snapMoveStep);
-                        obj3d.y = snap(quantize(newMat.ty, posQuant), snapMoveStep);
-                        obj3d.z = snap(quantize(newMat.tz, posQuant), snapMoveStep);
-                    }
-                    else { // Don't snap translation if the primary action wasn't a translation (i.e. Rotation around a pivot)
+						  if (translate != null && translate.length() > 0.0001 && snapForceOnGrid) {
+								obj3d.x = snap(quantize(newMat.tx, posQuant), snapMoveStep);
+								obj3d.y = snap(quantize(newMat.ty, posQuant), snapMoveStep);
+								obj3d.z = snap(quantize(newMat.tz, posQuant), snapMoveStep);
+						  }
+						  else { // Don't snap translation if the primary action wasn't a translation (i.e. Rotation around a pivot)
 						obj3d.x = quantize(newMat.tx, posQuant);
 						obj3d.y = quantize(newMat.ty, posQuant);
 						obj3d.z = quantize(newMat.tz, posQuant);
 					}
 
-                    if (rot != null) {
-                        obj3d.rotationX = quantize(M.radToDeg(euler.x), rotQuant);
-                        obj3d.rotationY = quantize(M.radToDeg(euler.y), rotQuant);
-                        obj3d.rotationZ = quantize(M.radToDeg(euler.z), rotQuant);
+						  if (rot != null) {
+								obj3d.rotationX = quantize(M.radToDeg(euler.x), rotQuant);
+								obj3d.rotationY = quantize(M.radToDeg(euler.y), rotQuant);
+								obj3d.rotationZ = quantize(M.radToDeg(euler.z), rotQuant);
 					}
 
 					if(scale != null) {
@@ -2960,10 +2982,10 @@ class SceneEditor {
 			var engine = h3d.Engine.getCurrent();
 			var ratio = 150 / engine.height;
 
-            var scale = ratio * distToCam * Math.tan(cam.fovY * 0.5 * Math.PI / 180.0);
-            if (cam.orthoBounds != null) {
-                scale = ratio *  (cam.orthoBounds.xSize) * 0.5;
-            }
+				var scale = ratio * distToCam * Math.tan(cam.fovY * 0.5 * Math.PI / 180.0);
+				if (cam.orthoBounds != null) {
+					 scale = ratio *  (cam.orthoBounds.xSize) * 0.5;
+				}
 			basis.setScale(scale);
 
 		} else {
@@ -4089,7 +4111,7 @@ class SceneEditor {
 	function groupSelection() {
 		if(!canGroupSelection()) {
 			return;
-        }
+		  }
 
 		// Sort the selection to match the scene order
 		var elts : Array<hrt.prefab.Prefab> = [];

--- a/hide/comp/SceneEditor.hx
+++ b/hide/comp/SceneEditor.hx
@@ -3181,18 +3181,18 @@ class SceneEditor {
 			var path = modifiedRef.source;
 
 			var others = sceneData.findAll(Reference, (r) -> r.source == path && r != modifiedRef, true);
-			// @:privateAccess
-			// if (others.length > 0) {
-			// 	var data = modifiedRef.refInstance.serialize();
-			// 	beginRebuild();
-			// 	for (ref in others) {
-			// 		removeInstance(ref.refInstance, false);
-			// 		@:privateAccess ref.setRef(data);
-			// 		queueRebuild(ref);
-			// 	}
-			// 	endRebuild();
-			// 	refreshTree();
-			// }
+			@:privateAccess
+			if (others.length > 0) {
+				var data = modifiedRef.refInstance.serialize();
+				beginRebuild();
+				for (ref in others) {
+					removeInstance(ref.refInstance, false);
+					@:privateAccess ref.setRef(data);
+					queueRebuild(ref);
+				}
+				endRebuild();
+				refreshTree();
+			}
 		}
 
 		applySceneStyle(p);

--- a/hide/comp/SceneEditor.hx
+++ b/hide/comp/SceneEditor.hx
@@ -3231,20 +3231,56 @@ class SceneEditor {
 
 		// reference
 		var isOverride = false;
+		var isOverriden = false;
+		var isOverridenNew = false;
 		var inRef = false;
 		if (p.shared.parentPrefab != null) {
 			var parentRef = Std.downcast(p.shared.parentPrefab, Reference);
 			if (parentRef != null) {
 				if (parentRef.editMode == Override) {
 					isOverride = true;
+
+					var path = [];
+					var current = p;
+					while (current != null) {
+						path.push(current);
+						current = current.parent;
+					}
+
+					var currentOverride = @:privateAccess parentRef.computeDiffFromSource();
+
+					// skip first item in the path
+					path.pop();
+					while(currentOverride != null && path.length > 0) {
+						var current = path.pop();
+						if (currentOverride.children != null) {
+							currentOverride = Reflect.field(currentOverride.children, current.name);
+						}
+					}
+
+					if (currentOverride != null) {
+						var overridenFields = Reflect.fields(currentOverride);
+						overridenFields.remove("children");
+						if (overridenFields.length > 0) {
+							isOverriden = true;
+							if (currentOverride.type != null) {
+								isOverridenNew = true;
+							}
+						}
+					}
+
 				} else {
 					inRef = true;
 				}
 			}
 		}
 
+
 		el.toggleClass("inRef", inRef);
 		el.toggleClass("isOverride", isOverride);
+		el.toggleClass("isOverriden", isOverriden);
+		el.toggleClass("isOverridenNew", isOverridenNew);
+
 
 		var tag = getTag(p);
 

--- a/hide/comp/SceneEditor.hx
+++ b/hide/comp/SceneEditor.hx
@@ -2141,7 +2141,7 @@ class SceneEditor {
 
 		onSceneReady();
 
-		selectElements([]);
+		selectElements([], NoHistory);
 		this.camera2D = camera2D;
 
 		updateViewportOverlays();

--- a/hide/view/Model.hx
+++ b/hide/view/Model.hx
@@ -80,11 +80,12 @@ class Model extends FileView {
 		tabs = new hide.comp.Tabs(null,element.find(".tabs"));
 		eventList = element.find(".event-editor");
 
-		root = new hrt.prefab.Prefab(null, null);
 		var def = new hrt.prefab.Prefab(null, null);
 		new hrt.prefab.RenderProps(def, null).name = "renderer";
 		var l = new hrt.prefab.Light(def, null);
-		sceneEditor = new hide.comp.SceneEditor(this, root);
+		sceneEditor = new hide.comp.SceneEditor(this);
+		sceneEditor.onSceneReady = onSceneReady;
+
 		sceneEditor.editorDisplay = false;
 		sceneEditor.onRefresh = onRefresh;
 		sceneEditor.onUpdate = onUpdate;
@@ -1199,6 +1200,11 @@ class Model extends FileView {
 
 	// Scene editor bindings
 	inline function get_scene() return sceneEditor.scene;
+
+	function onSceneReady() {
+		root = new hrt.prefab.Prefab(null, null);
+		sceneEditor.setPrefab(root);
+	}
 
 	function onRefresh() {
 		this.saveDisplayKey = "Model:" + state.path;

--- a/hide/view/Prefab.hx
+++ b/hide/view/Prefab.hx
@@ -52,8 +52,8 @@ class FiltersPopup extends hide.comp.Popup {
 class PrefabSceneEditor extends hide.comp.SceneEditor {
 	var parent : Prefab;
 
-	public function new(view, data) {
-		super(view, data);
+	public function new(view) {
+		super(view);
 		parent = cast view;
 		this.localTransform = false; // TODO: Expose option
 	}
@@ -61,11 +61,6 @@ class PrefabSceneEditor extends hide.comp.SceneEditor {
 	override function update(dt) {
 		super.update(dt);
 		parent.onUpdate(dt);
-	}
-
-	override function onSceneReady() {
-		super.onSceneReady();
-		parent.onSceneReady();
 	}
 
 	override function applyTreeStyle(p: PrefabElement, el: Element, ?pname: String, ?tree: hide.comp.IconTree<PrefabElement>) {
@@ -239,7 +234,8 @@ class Prefab extends hide.view.FileView {
 	}
 
 	function createEditor() {
-		sceneEditor = new PrefabSceneEditor(this, data);
+		sceneEditor = new PrefabSceneEditor(this);
+		sceneEditor.onSceneReady = onSceneReady;
 		for (callback in sceneReadyDelayed) {
 			sceneEditor.delayReady(callback);
 		}
@@ -437,12 +433,6 @@ class Prefab extends hide.view.FileView {
 	}
 
 	public function onSceneReady() {
-		data = hxd.res.Loader.currentInstance.load(state.path).toPrefab().load();
-
-		@:privateAccess sceneEditor.sceneData = data;
-
-		sceneEditor.refreshScene();
-
 		refreshSceneFilters();
 		refreshGraphicsFilters();
 		refreshViewModes();

--- a/hide/view/Prefab.hx
+++ b/hide/view/Prefab.hx
@@ -433,6 +433,9 @@ class Prefab extends hide.view.FileView {
 	}
 
 	public function onSceneReady() {
+		data = hxd.res.Loader.currentInstance.load(state.path).toPrefab().load().clone();
+		sceneEditor.setPrefab(cast data);
+
 		refreshSceneFilters();
 		refreshGraphicsFilters();
 		refreshViewModes();

--- a/hide/view/Prefab.hx
+++ b/hide/view/Prefab.hx
@@ -248,10 +248,8 @@ class Prefab extends hide.view.FileView {
 
 	override function onDisplay() {
 		if( sceneEditor != null ) sceneEditor.dispose();
-
 		createData();
 		var content = sys.io.File.getContent(getPath());
-		data = hrt.prefab.Prefab.createFromDynamic(haxe.Json.parse(content));
 		currentSign = ide.makeSignature(content);
 
 
@@ -439,6 +437,12 @@ class Prefab extends hide.view.FileView {
 	}
 
 	public function onSceneReady() {
+		data = hxd.res.Loader.currentInstance.load(state.path).toPrefab().load();
+
+		@:privateAccess sceneEditor.sceneData = data;
+
+		sceneEditor.refreshScene();
+
 		refreshSceneFilters();
 		refreshGraphicsFilters();
 		refreshViewModes();
@@ -578,6 +582,7 @@ class Prefab extends hide.view.FileView {
 			initGraphicsFilters();
 			initSceneFilters();
 		}
+
 	}
 
 	function resetCamera( top : Bool ) {

--- a/hrt/prefab/Diff.hx
+++ b/hrt/prefab/Diff.hx
@@ -74,7 +74,7 @@ class Diff {
 				var key = name;
 
 				#if editor
-				if (originalChild.child.type == null || modifiedChild.child.type == null) {
+				if ((originalChild?.child != null && originalChild.child.type == null) || (modifiedChild?.child != null && modifiedChild.child.type == null)) {
 					throw "can't diff child that have a missing `type`";
 				}
 				#end

--- a/hrt/prefab/Diff.hx
+++ b/hrt/prefab/Diff.hx
@@ -26,6 +26,10 @@ enum DiffResult {
 
 **/
 class Diff {
+
+	/**
+		Add or Set a key/value pair to a DiffResult. If "diff" was a Skip, it will become a Set({key: value})
+	**/
 	public static function addToDiff(diff: DiffResult, key: String, value: Dynamic) : DiffResult{
 		var v = switch(diff) {
 			case Skip:
@@ -41,7 +45,6 @@ class Diff {
 	public static function deepCopy(v:Dynamic) : Dynamic {
 		return haxe.Json.parse(haxe.Json.stringify(v));
 	}
-
 
 	/**
 		Returns the difference of two values together
@@ -201,6 +204,10 @@ class Diff {
 		return Set(result);
 	}
 
+	/**
+		Returns the difference between two arrays. If the arrays are found to be different, a full copy of
+		modified will be returned as a Set()
+	**/
 	public static function diffArray(original: Array<Dynamic>, modified: Dynamic) : DiffResult {
 		if (original.length != modified.length) {
 			return Set(deepCopy(modified));
@@ -313,10 +320,6 @@ class Diff {
 				}
 				continue;
 			}
-
-			// if (field.charAt(0) == "@") {
-			// 	continue;
-			// }
 
 			var targetValue = Reflect.getProperty(target, field);
 			var diffValue = Reflect.getProperty(diff, field);

--- a/hrt/prefab/Diff.hx
+++ b/hrt/prefab/Diff.hx
@@ -1,0 +1,278 @@
+package hrt.prefab;
+
+enum DiffResult {
+	Skip;
+	Set(value: Dynamic);
+}
+
+class Diff {
+	public static function addToDiff(diff: DiffResult, key: String, value: Dynamic) : DiffResult{
+		var v = switch(diff) {
+			case Skip:
+				var v = {};
+				Reflect.setField(v, key, value);
+				return Set(v);
+			case Set(v):
+				Reflect.setField(v, key, value);
+				return diff;
+		}
+	}
+
+	public static function deepCopy(v:Dynamic) : Dynamic {
+		return haxe.Json.parse(haxe.Json.stringify(v));
+	}
+
+	public static function diffPrefab(original: Dynamic, modified: Dynamic) : DiffResult {
+		if (original == null || modified == null) {
+			if (original == modified)
+				return Skip;
+			return Set(deepCopy(modified));
+		}
+
+		if (original.type != modified.type)
+			return Set(deepCopy(modified));
+
+		var result = diffObject(original, modified, ["children"]); // we could skip "type" but because we are sure that the type are equals they will never be serialised
+
+		var resultChildren = {};
+
+		var originalChildren = original.children ?? [];
+		var modifiedChildren = modified.children ?? [];
+
+		var childrenMap : Map<String, {originals: Array<Dynamic>, modifieds: Array<Dynamic>}> = [];
+
+		for (index => child in originalChildren) {
+			hrt.tools.MapUtils.getOrPut(childrenMap, child.name ?? "", {originals: [], modifieds: []}).originals.push({index: index, child: child});
+		}
+
+		for (index => child in modifiedChildren) {
+			hrt.tools.MapUtils.getOrPut(childrenMap, child.name ?? "", {originals: [], modifieds: []}).modifieds.push({index: index, child: child});
+		}
+
+		for (name => data in childrenMap) {
+			for (index in 0...hxd.Math.imax(data.originals.length, data.modifieds.length)) {
+				var originalChild = data.originals[index];
+				var modifiedChild = data.modifieds[index];
+				var key = name;
+				if (index > 0)
+					key += '@$index';
+
+				var diff = diffPrefab(originalChild?.child, modifiedChild?.child);
+
+				if (originalChild?.index != modifiedChild?.index) {
+					if (modifiedChild?.index != null) {
+						diff = addToDiff(diff, "@index", modifiedChild.index);
+					}
+				}
+
+				switch(diff) {
+					case Skip:
+					case Set(value):
+						Reflect.setField(resultChildren, key, value);
+				}
+			}
+		}
+
+		if (Reflect.fields(resultChildren).length > 0) {
+			result = addToDiff(result, "children", resultChildren);
+		}
+
+		return result;
+	}
+
+	public static function diffObject(original: Dynamic, modified: Dynamic, skipFields: Array<String> = null) : DiffResult {
+		skipFields ??= [];
+		var result = {};
+		var removedFields : Array<String> = [];
+
+		if (original == null || modified == null) {
+			if (original == modified)
+				return Skip;
+			return Set(deepCopy(modified));
+		}
+
+		// Mark fields as removed
+		for (originalField in Reflect.fields(original)) {
+			if (skipFields.contains(originalField))
+				continue;
+
+			if (!Reflect.hasField(modified, originalField)) {
+				removedFields.push(originalField);
+				continue;
+			}
+		}
+
+		for (modifiedField in Reflect.fields(modified)) {
+			if (skipFields.contains(modifiedField))
+				continue;
+
+			var originalValue = Reflect.getProperty(original, modifiedField);
+			var modifiedValue = Reflect.getProperty(modified, modifiedField);
+
+			switch(diffValue(originalValue, modifiedValue)) {
+				case Skip:
+				case Set(v):
+					Reflect.setField(result, modifiedField, v);
+			}
+		}
+
+		if (removedFields.length > 0) {
+			Reflect.setField(result, "@removed", removedFields);
+		}
+
+		if (Reflect.fields(result).length == 0)
+			return Skip;
+		return Set(result);
+	}
+
+	public static function diffArray(original: Array<Dynamic>, modified: Dynamic) : DiffResult {
+		if (original.length != modified.length) {
+			return Set(deepCopy(modified));
+		}
+
+		for (index in 0...original.length) {
+			var originalValue = original[index];
+			var modifiedValue = modified[index];
+
+			switch(diffValue(originalValue, modifiedValue)) {
+				case Set(_):
+					// return the whole modified object when any field is different than the original
+					return Set(deepCopy(modified));
+				case Skip:
+			}
+		}
+		return Skip;
+	}
+
+	public static function diffValue(originalValue: Dynamic, modifiedValue: Dynamic) : DiffResult {
+		var originalType = Type.typeof(originalValue);
+		var modifiedType = Type.typeof(modifiedValue);
+
+		if (!originalType.equals(modifiedType)) {
+			return Set(modifiedValue);
+		}
+
+		switch (modifiedType) {
+			case TNull:
+				// The only way we get here is if both types are null, so by definition they are both null and so there is no diff
+				return Skip;
+			case TInt | TFloat | TBool:
+				if (originalValue == modifiedValue) {
+					return Skip;
+				}
+			case TObject:
+				return diffObject(originalValue, modifiedValue);
+			case TClass(subClass): {
+				switch (subClass) {
+					case String:
+						if (originalValue == modifiedValue) {
+							return Skip;
+						}
+					case Array:
+						return diffArray(originalValue, modifiedValue);
+					default:
+						throw "Can't diff class " + subClass;
+				}
+			}
+			default:
+				throw "Unhandled type " + modifiedType;
+		}
+		return Set(modifiedValue);
+	}
+
+	/**
+		Modifies `target` dynamic so `apply(a, diff(a, b)) == b`
+	**/
+	public static function apply(target: Dynamic, diff: Dynamic) {
+		if (diff == null)
+			return null;
+
+		if (target == null)
+			target = {};
+
+		if (diff.type != null && diff.type != target.type) {
+			return diff;
+		}
+
+		for (field in Reflect.fields(diff)) {
+			if (field == "children")
+			{
+				var targetChildren = Reflect.field(target, "children") ?? [];
+				var diffChildren = Reflect.field(diff, "children");
+
+				var finalChildren = [];
+
+				for (index => child in targetChildren) {
+					finalChildren[index] = child;
+				}
+
+				for (fields in Reflect.fields(diffChildren)) {
+					var diffChild = Reflect.field(diffChildren, fields);
+					var name = fields;
+					var split = name.split("@");
+					var nthChild = 0;
+					if (split.length == 2) {
+						name = split[0];
+						nthChild = Std.parseInt(split[1]);
+					}
+
+					var targetChild = null;
+					var finalIndex = 0;
+					for (index => child in targetChildren) {
+						if (name == child.name) {
+							if (nthChild == 0) {
+								targetChild = child;
+								finalIndex = index;
+								break;
+							} else {
+								nthChild --;
+							}
+						}
+					}
+
+					// Remove child if null
+					if (diffChild == null) {
+						finalChildren.splice(finalIndex, 1);
+						continue;
+					}
+
+					var modifiedChild = apply(targetChild, diffChild);
+					finalIndex = Reflect.field(diffChild, "@index") ?? finalIndex;
+
+					finalChildren[finalIndex] = modifiedChild;
+				}
+
+				Reflect.setField(target, "children", finalChildren);
+				continue;
+			}
+
+			if (field == "@removed") {
+				var removed = Reflect.field(diff, "@removed");
+				for (field in (removed:Array<String>)) {
+					Reflect.deleteField(target, field);
+				}
+				continue;
+			}
+
+			if (field.charAt(0) == "@") {
+				continue;
+			}
+
+			var targetValue = Reflect.getProperty(target, field);
+			var diffValue = Reflect.getProperty(diff, field);
+
+			var targetType = Type.typeof(targetValue);
+			var diffType = Type.typeof(diffValue);
+
+			switch (targetType) {
+				case TNull | TInt | TFloat | TBool | TClass(Array) | TClass(String):
+					Reflect.setField(target, field, diffValue);
+				case TObject:
+					apply(targetValue, diffValue);
+				default:
+					throw "unhandeld type " + targetType;
+			}
+		}
+		return target;
+	}
+}

--- a/hrt/prefab/Light.hx
+++ b/hrt/prefab/Light.hx
@@ -179,7 +179,7 @@ class Light extends Object3D {
 		}
 
 		#if editor
-		if (shared.parentPrefab == null || (Std.downcast(shared.parentPrefab, Reference)?.editMode && shared.parentPrefab != shared.editor?.renderPropsRoot)) {
+		if (shared.parentPrefab == null || (Std.downcast(shared.parentPrefab, Reference)?.editMode != None && shared.parentPrefab != shared.editor?.renderPropsRoot)) {
 			icon = hrt.impl.EditorTools.create3DIcon(object, hide.Ide.inst.getHideResPath("icons/PointLight.png"), 0.5, Light);
 		}
 		#end

--- a/hrt/prefab/Prefab.hx
+++ b/hrt/prefab/Prefab.hx
@@ -63,7 +63,11 @@ class Prefab {
 	/**
 		The associated source file (an image, a 3D model, etc.) if the prefab type needs it.
 	**/
-	@:s public var source : String;
+	@:s public var source(default, set) : String;
+
+	public function set_source(newSource: String) {
+		return source = newSource;
+	}
 
 	/**
 		The parent of the prefab in the tree view

--- a/hrt/prefab/Prefab.hx
+++ b/hrt/prefab/Prefab.hx
@@ -520,6 +520,13 @@ class Prefab {
 		return [].iterator();
 	}
 
+
+	/**
+		Returns a name that will allow to disambiguate this
+		prefabs from siblings with the same name
+		Prefab with more than one sibling with the same name
+		will have their name formated as `name-<index>` unless their index is 0.
+	**/
 	public function getUniqueName() {
 		if (parent == null) {
 			return "";
@@ -742,6 +749,7 @@ class Prefab {
 	/**
 		Finds a prefab by folowing a dot separated path like this one : `parent.child.grandchild`.
 		Returns null if the path is invalid or does not match any prefabs in the hierarchy
+		If the path contains many prefabs with the same name, they can be disambiguated in the path with `name-index`
 	**/
 	public function locatePrefab(path: String) : Null<Prefab> {
 		if (path == null)

--- a/hrt/prefab/Reference.hx
+++ b/hrt/prefab/Reference.hx
@@ -74,25 +74,25 @@ class Reference extends Object3D {
 	#end
 
 	function setRef(data: Dynamic) {
-		// #if editor
-		// var currentModifications = null;
-		// if (originalSource != null && refInstance != null) {
-		// 	currentModifications = genOverride();
-		// 	trace(this.name, currentModifications);
-		// }
-		// originalSource = hrt.prefab.Diff.deepCopy(data);
-		// #end
+		#if editor
+		var currentModifications = null;
+		if (originalSource != null && refInstance != null) {
+			currentModifications = genOverride();
+			trace(this.name, currentModifications);
+		}
+		originalSource = hrt.prefab.Diff.deepCopy(data);
+		#end
 
 		originalSource = hrt.prefab.Diff.deepCopy(data);
 
-		if (/*#if editor currentModifications == null && #end*/ overrides != null) {
+		if (#if editor currentModifications == null && #end overrides != null) {
 			data = hrt.prefab.Diff.apply(hrt.prefab.Diff.deepCopy(data), overrides);
 		}
-		// #if editor
-		// else if (currentModifications != null) {
-		// 	data = hrt.prefab.Diff.apply(data, currentModifications);
-		// }
-		// #end
+		#if editor
+		else if (currentModifications != null) {
+			data = hrt.prefab.Diff.apply(data, currentModifications);
+		}
+		#end
 
 		refInstance = Prefab.createFromDynamic(data, new ContextShared(source, true));
 		refInstance.shared.parentPrefab = this;

--- a/hrt/prefab/Reference.hx
+++ b/hrt/prefab/Reference.hx
@@ -18,6 +18,7 @@ class Reference extends Object3D {
 	public var originalSource : Dynamic;
 	#end
 
+	#if editor
 	function genOverride() : Dynamic {
 		var orig = hrt.prefab.Diff.deepCopy(originalSource);
 		var ref = refInstance.serialize();
@@ -29,13 +30,16 @@ class Reference extends Object3D {
 				return v;
 		}
 	}
+	#end
 
 	override function save() {
+		#if editor
 		if (editMode == Override && refInstance != null) {
 			this.overrides = genOverride();
 		} else if (editMode == Edit && refInstance != null) {
 			this.overrides = null;
 		}
+		#end
 
 		var obj : Dynamic = super.save();
 		#if editor
@@ -85,7 +89,6 @@ class Reference extends Object3D {
 		originalSource = hrt.prefab.Diff.deepCopy(data);
 		#end
 
-		originalSource = hrt.prefab.Diff.deepCopy(data);
 
 		if (#if editor currentModifications == null && #end overrides != null) {
 			data = hrt.prefab.Diff.apply(hrt.prefab.Diff.deepCopy(data), overrides);

--- a/hrt/prefab/Reference.hx
+++ b/hrt/prefab/Reference.hx
@@ -101,7 +101,9 @@ class Reference extends Object3D {
 			} else {
 				initRefInstance();
 			}
-			refInstance?.shared.parentPrefab = this;
+			if (refInstance != null) {
+				refInstance.shared.parentPrefab = this;
+			}
 		}
 	}
 

--- a/hrt/prefab/Reference.hx
+++ b/hrt/prefab/Reference.hx
@@ -61,12 +61,10 @@ class Reference extends Object3D {
 	}
 
 	override function load(obj: Dynamic) {
-		#if editor
 		// Backward compatibility between old bool editMode and new enum based editMode
 		if (Type.typeof(obj.editMode) == TBool) {
 			obj.editMode = "Edit";
 		}
-		#end
 
 		super.load(obj);
 

--- a/hrt/prefab/Reference.hx
+++ b/hrt/prefab/Reference.hx
@@ -80,6 +80,19 @@ class Reference extends Object3D {
 	#end
 
 	function setRef(data: Dynamic) {
+		if (overrides == null) {
+			refInstance = hxd.res.Loader.currentInstance.load(source).toPrefab().load().clone();
+			return;
+		}
+
+		if (data == null) {
+			if (overrides != null) {
+				// need a fresh copy to apply overrides
+				data = @:privateAccess hxd.res.Loader.currentInstance.load(source).toPrefab().loadData();
+			} else {
+				data = @:privateAccess hxd.res.Loader.currentInstance.load(source).toPrefab().loadDataCached();
+			}
+		}
 		#if editor
 		var currentModifications = null;
 		if (originalSource != null && refInstance != null) {
@@ -87,11 +100,14 @@ class Reference extends Object3D {
 			trace(this.name, currentModifications);
 		}
 		originalSource = hrt.prefab.Diff.deepCopy(data);
+		if (overrides != null) {
+			data = hrt.prefab.Diff.deepCopy(data);
+		}
 		#end
 
 
 		if (#if editor currentModifications == null && #end overrides != null) {
-			data = hrt.prefab.Diff.apply(hrt.prefab.Diff.deepCopy(data), overrides);
+			data = hrt.prefab.Diff.apply(data, overrides);
 		}
 		#if editor
 		else if (currentModifications != null) {
@@ -111,7 +127,7 @@ class Reference extends Object3D {
 		#if editor
 		try {
 		#end
-			setRef(@:privateAccess hxd.res.Loader.currentInstance.load(source).toPrefab().loadData());
+			setRef(null);
 			return refInstance;
 		#if editor
 		} catch (_) {

--- a/hrt/prefab/Reference.hx
+++ b/hrt/prefab/Reference.hx
@@ -80,18 +80,15 @@ class Reference extends Object3D {
 	#end
 
 	function setRef(data: Dynamic) {
+		// Fast non override path
 		if (overrides == null) {
 			refInstance = hxd.res.Loader.currentInstance.load(source).toPrefab().load().clone();
 			return;
 		}
 
 		if (data == null) {
-			if (overrides != null) {
 				// need a fresh copy to apply overrides
 				data = @:privateAccess hxd.res.Loader.currentInstance.load(source).toPrefab().loadData();
-			} else {
-				data = @:privateAccess hxd.res.Loader.currentInstance.load(source).toPrefab().loadDataCached();
-			}
 		}
 		#if editor
 		var currentModifications = null;

--- a/hrt/prefab/Reference.hx
+++ b/hrt/prefab/Reference.hx
@@ -9,11 +9,7 @@ class Reference extends Object3D {
 	@:s public var editMode : EditMode = None;
 	@:s public var overrides : Dynamic = null;
 
-	public var refInstance(default, set) : Prefab;
-	function set_refInstance(v: Prefab) {
-		trace("setRefInstance");
-		return refInstance = v;
-	}
+	public var refInstance : Prefab;
 
 	#if editor
 	var wasMade : Bool = false;
@@ -338,10 +334,11 @@ class Reference extends Object3D {
 			<div class="group" name="Reference">
 			<dl>
 				<dt>Reference</dt><dd><input type="fileselect" extensions="prefab l3d fx" field="source"/></dd>
-				<dt>Edit</dt><dd><select field="editMode"></select></dd>
+				<dt>Edit</dt><dd><select field="editMode" class="monSelector"></select></dd>
 				<p class="warning">Warning : Edit mode enabled while there are override on this reference. Saving will cause the overrides to be applied to the original reference !</p>
 			</dl>
 			</div>');
+
 
 		var warning = element.find(".warning");
 

--- a/hrt/prefab/Reference.hx
+++ b/hrt/prefab/Reference.hx
@@ -74,23 +74,25 @@ class Reference extends Object3D {
 	#end
 
 	function setRef(data: Dynamic) {
-		#if editor
-		var currentModifications = null;
-		if (originalSource != null && refInstance != null) {
-			currentModifications = genOverride();
-			trace(currentModifications);
-		}
-		originalSource = data;
-		#end
+		// #if editor
+		// var currentModifications = null;
+		// if (originalSource != null && refInstance != null) {
+		// 	currentModifications = genOverride();
+		// 	trace(this.name, currentModifications);
+		// }
+		// originalSource = hrt.prefab.Diff.deepCopy(data);
+		// #end
 
-		if (overrides != null) {
+		originalSource = hrt.prefab.Diff.deepCopy(data);
+
+		if (/*#if editor currentModifications == null && #end*/ overrides != null) {
 			data = hrt.prefab.Diff.apply(hrt.prefab.Diff.deepCopy(data), overrides);
 		}
-		#if editor
-		if (currentModifications != null) {
-			data = hrt.prefab.Diff.apply(data, currentModifications);
-		}
-		#end
+		// #if editor
+		// else if (currentModifications != null) {
+		// 	data = hrt.prefab.Diff.apply(data, currentModifications);
+		// }
+		// #end
 
 		refInstance = Prefab.createFromDynamic(data, new ContextShared(source, true));
 		refInstance.shared.parentPrefab = this;

--- a/hrt/prefab/Resource.hx
+++ b/hrt/prefab/Resource.hx
@@ -4,8 +4,6 @@ package hrt.prefab;
 class Resource extends hxd.res.Resource {
 
 	var prefab : Prefab;
-	var diskData : Dynamic;
-	var isBSON : Bool = false;
 	var cacheVersion : Int;
 	var isWatched : Bool;
 
@@ -28,13 +26,9 @@ class Resource extends hxd.res.Resource {
 		});
 	}
 
-	function loadData() : Dynamic {
-		if (diskData == null || cacheVersion != CACHE_VERSION) {
-			isBSON = entry.fetchBytes(0,1).get(0) == 'H'.code;
-			diskData = isBSON ? entry.getBytes() : entry.getText();
-		}
-
-		return isBSON ? new hxd.fmt.hbson.Reader(diskData, false).read() : haxe.Json.parse(diskData);
+	function loadData() {
+		var isBSON = entry.fetchBytes(0,1).get(0) == 'H'.code;
+		return isBSON ? new hxd.fmt.hbson.Reader(entry.getBytes(),false).read() : haxe.Json.parse(entry.getText());
 	}
 
 	public function load() : Prefab {

--- a/hrt/prefab/Resource.hx
+++ b/hrt/prefab/Resource.hx
@@ -4,6 +4,7 @@ package hrt.prefab;
 class Resource extends hxd.res.Resource {
 
 	var prefab : Prefab;
+	var cachedData : Dynamic;
 	var cacheVersion : Int;
 	var isWatched : Bool;
 
@@ -28,7 +29,14 @@ class Resource extends hxd.res.Resource {
 
 	function loadData() {
 		var isBSON = entry.fetchBytes(0,1).get(0) == 'H'.code;
-		return isBSON ? new hxd.fmt.hbson.Reader(entry.getBytes(),false).read() : haxe.Json.parse(entry.getText());
+		cachedData = isBSON ? new hxd.fmt.hbson.Reader(entry.getBytes(),false).read() : haxe.Json.parse(entry.getText());
+		return cachedData;
+	}
+
+	public function loadDataCached() {
+		if (cachedData != null && cacheVersion == CACHE_VERSION)
+			return cachedData;
+		return loadData();
 	}
 
 	public function load() : Prefab {

--- a/hrt/prefab/Resource.hx
+++ b/hrt/prefab/Resource.hx
@@ -4,7 +4,8 @@ package hrt.prefab;
 class Resource extends hxd.res.Resource {
 
 	var prefab : Prefab;
-	var cachedData : Dynamic;
+	var diskData : Dynamic;
+	var isBSON : Bool = false;
 	var cacheVersion : Int;
 	var isWatched : Bool;
 
@@ -27,16 +28,13 @@ class Resource extends hxd.res.Resource {
 		});
 	}
 
-	function loadData() {
-		var isBSON = entry.fetchBytes(0,1).get(0) == 'H'.code;
-		cachedData = isBSON ? new hxd.fmt.hbson.Reader(entry.getBytes(),false).read() : haxe.Json.parse(entry.getText());
-		return cachedData;
-	}
+	function loadData() : Dynamic {
+		if (diskData == null || cacheVersion != CACHE_VERSION) {
+			isBSON = entry.fetchBytes(0,1).get(0) == 'H'.code;
+			diskData = isBSON ? entry.getBytes() : entry.getText();
+		}
 
-	public function loadDataCached() {
-		if (cachedData != null && cacheVersion == CACHE_VERSION)
-			return cachedData;
-		return loadData();
+		return isBSON ? new hxd.fmt.hbson.Reader(diskData, false).read() : haxe.Json.parse(diskData);
 	}
 
 	public function load() : Prefab {

--- a/hrt/prefab/Shader.hx
+++ b/hrt/prefab/Shader.hx
@@ -203,8 +203,10 @@ class Shader extends Prefab {
 	#if editor
 
 	override function editorRemoveInstanceObjects() : Void {
-		shared.editor.queueRebuild(parent);
-		super.editorRemoveInstanceObjects();
+		if (shared?.editor != null) {
+			shared.editor.queueRebuild(parent);
+			super.editorRemoveInstanceObjects();
+		}
 	}
 
 	function getEditProps(shaderDef: hxsl.SharedShader) : Array<hrt.prefab.Props.PropDef> {

--- a/hrt/tools/MapUtils.hx
+++ b/hrt/tools/MapUtils.hx
@@ -3,7 +3,7 @@ import haxe.macro.Expr;
 
 class MapUtils {
 	/**
-		Returns map[key] if key if present, else execute def and puts it into map[key]
+		Returns `map[key]` if key if present, else evaluate `def` and puts the result into `map[key]`, then retunrs `map[key]`
 	**/
 	macro public static function getOrPut<K, V>(map:ExprOf<Map<K, V>>, key:ExprOf<K>, def:ExprOf<V>):Expr {
 		return macro {


### PR DESCRIPTION
This allow reference prefabs to make local changes to the referenced prefab without modifying it. A new "Override" mode is available in the editor that allow the user to changes the referenced prefab like the "Edit Mode", but on save a Diff between the referenced prefab and the local copy will be computed and saved in the "overrides" field of the Reference. When a Reference has any overrides, they will be applied to the referenced prefab before it is loaded into the reference.