### PR TITLE
support for definition of multiple classes through `props.json`

### DIFF
--- a/hide/comp/SceneEditor.hx
+++ b/hide/comp/SceneEditor.hx
@@ -5738,7 +5738,7 @@ class SceneEditor {
 			var parts = g.split("|");
 			final classes : Array<Dynamic> = [];
 			for (partIdx in 1...parts.length) {
-				var cl : Dynamic = Type.resolveClass(parts[partIdx]);
+				var cl : Class<Dynamic> = Type.resolveClass(parts[partIdx]);
 				if( cl == null ) continue;
 				classes.push(cl);
 			}


### PR DESCRIPTION
adds support for multiple classes for scene editor context menu, such as 
```
	"sceneeditor.newgroups": [
		"Custom|common.CustomObject|plugins.recast_detour.src.RecastPrefab",
	]
```
